### PR TITLE
Initial geometric measures for fibers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,27 @@ Analysis functionality for subcellular models
 ## Quickstart
 
 ```python
-from subcell_analysis import example
+import numpy as np
+from subcell_analysis.compression_analysis import get_end_to_end_axis_distances_and_projections
 
-print(example.str_len("hello"))  # prints 5
+test_polymer_trace = np.array([
+    [2,0,0],
+    [4,1,0],
+    [6,0,-1],
+    [8,0,0],
+])
+
+# prints the following:
+# distance of polymer trace points from the end-to-end axis:
+# (array([0., 1., 1., 0.])
+# scaled distances of projection points along the end-to-end-axis:
+# array([0., 0.33, 0.67, 1.]),
+# positions of projection points on the end-to-end axis:
+# array([[2., 0., 0.],
+#        [4., 0., 0.],
+#        [6., 0., 0.],
+#        [8., 0., 0.]]))
+print(get_end_to_end_axis_distances_and_projections(test_polymer_trace))
 ```
 
 ## Documentation
@@ -36,5 +54,15 @@ For full package documentation please visit [Simularium.github.io/subcell-analys
 ## Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for information related to developing the code.
+
+## Glossary of terms
+Definitions of some terms used in these analyses
+* *polymer trace*:
+
+    refers to the line traced by a polymer backbone in three dimensions. For cytosim, this corresponds to the positions of the control points. For ReaDDy, this corresponds to a derived metric that traces the polymer backbone
+
+* *end-to-end axis*:
+
+    refers to the line connecting the first and last points of a polymer trace
 
 **Apache Software License 2.0**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dev = [
   "numpy",
   "pandas",
   "ipykernel",
+  "matplotlib",
 ]
 
 # entry points

--- a/subcell_analysis/compression_analysis.py
+++ b/subcell_analysis/compression_analysis.py
@@ -1,123 +1,167 @@
 #!/usr/bin/env python
+from typing import Tuple
 import numpy as np
 import matplotlib as plt
+
 # TODO: consider creating a fiber class?
 
 
 def asymmetry(fibers_df):
     last_timepoint = fibers_df.loc[timepoints[-1]]
-    last_timepoint_tension = last_timepoint['segment_energy']
+    last_timepoint_tension = last_timepoint["segment_energy"]
     diff = np.zeros(len(last_timepoint_tension))
     for index, timepoint in enumerate(last_timepoint_tension):
         middle_index = np.round(fiber_at_time.shape[0] / 2).astype(int)
-        diff[index] = np.abs(last_timepoint_tension[index] - last_timepoint_tension[-1-index])
-    xs = np.linspace(0,1,len(last_timepoint_tension))
+        diff[index] = np.abs(
+            last_timepoint_tension[index] - last_timepoint_tension[-1 - index]
+        )
+    xs = np.linspace(0, 1, len(last_timepoint_tension))
     plt.scatter(xs, diff)
-    plt.xlabel('Position along filament')
-    plt.ylabel('Level of Asymmetry')
-        #print(diff[index])
+    plt.xlabel("Position along filament")
+    plt.ylabel("Level of Asymmetry")
+    # print(diff[index])
     print(len(diff))
-    #write 
+    # write
 
 
-def get_axis_distances_and_projections(fiber_points):
+def get_end_to_end_axis_distances_and_projections(
+    polymer_trace: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
-    Returns the distances of fiber points from the axis
+    Returns the distances of the polymer trace points from the end-to-end axis.
+    Here, the end-to-end axis is defined as the line joining the first and last
+    fiber point.
 
     Parameters
     ----------
-    fiber_points: [n x 3] numpy array
-        array containing the x,y,z positions of fiber points
+    polymer_trace: [n x 3] numpy array
+        array containing the x,y,z positions of the polymer trace points
         at a given time
 
     Returns
     ----------
     perp_distances: [n x 1] numpy array
-        perpendicular distances of fiber points from the axis
+        perpendicular distances of the polymer trace from the end-to-end axis
 
     scaled_projections: [n x 1] numpy array
-        length of fiber point projections along the axis, scaled
+        length of fiber point projections along the end-to-end axis, scaled
         by axis length.
-        Can be negative.    
+        Can be negative.
+
+    projection_positions: [n x 3] numpy array
+        positions of points on the end-to-end axis that are
+        closest from the respective points in the polymer trace.
+        The distance from projection_positions
+        to the trace points is the shortest distance from the end-to-end axis
     """
-    axis = fiber_points[-1] - fiber_points[0]
-    axis_length = np.linalg.norm(axis)
+    end_to_end_axis = polymer_trace[-1] - polymer_trace[0]
+    end_to_end_axis_length = np.linalg.norm(end_to_end_axis)
 
-    position_vectors = fiber_points - fiber_points[0]
-    dot_products = np.dot(position_vectors, axis)
+    position_vectors = polymer_trace - polymer_trace[0]
+    dot_products = np.dot(position_vectors, end_to_end_axis)
 
-    projections = dot_products / axis_length
-    projection_positions = fiber_points[0] + projections[:, None] * axis / axis_length
+    projections = dot_products / end_to_end_axis_length
+    projection_positions = (
+        polymer_trace[0]
+        + projections[:, None] * end_to_end_axis / end_to_end_axis_length
+    )
 
-    perp_distances = np.linalg.norm(fiber_points - projection_positions, axis=1)
-    scaled_projections = projections / axis_length
+    perp_distances = np.linalg.norm(
+        polymer_trace - projection_positions, axis=1
+    )
+    scaled_projections = projections / end_to_end_axis_length
 
     return perp_distances, scaled_projections, projection_positions
 
 
-def get_average_distance_from_axis(fiber_points):
+def get_average_distance_from_end_to_end_axis(
+    polymer_trace: np.ndarray,
+) -> float:
     """
-    Returns the average perpendicular distance of fiber points from the axis
-    
+    Returns the average perpendicular distance of polymer trace points from
+    the end-to-end axis
+
     Parameters
     ----------
-    fiber_points: [n x 3] numpy array
-        array containing the x,y,z positions of fiber points
+    polymer_trace: [n x 3] numpy array
+        array containing the x,y,z positions of the polymer trace
         at a given time
-    
+
     Returns
     ----------
     avg_perp_distance: float
-        average perpendicular distance of fiber points from the axis
+        average perpendicular distance of polymer trace points from the
+        end-to-end axis
     """
-    perp_distances, _, _ = get_axis_distances_and_projections(fiber_points=fiber_points)
+    perp_distances, _, _ = get_end_to_end_axis_distances_and_projections(
+        polymer_trace=polymer_trace
+    )
     avg_perp_distance = np.nanmean(perp_distances)
 
     return avg_perp_distance
 
 
-def get_asymmetry_of_peak(fiber_points):
+def get_asymmetry_of_peak(
+    polymer_trace: np.ndarray,
+) -> float:
     """
-    returns the scaled distance of the projection of the peak from the axis midpoint
-    
+    returns the scaled distance of the projection of the peak from the
+    end-to-end axis midpoint
+
     Parameters
     ----------
-    fiber_points: [n x 3] numpy array
-        array containing the x,y,z positions of fiber points
+    polymer_trace: [n x 3] numpy array
+        array containing the x,y,z positions of the polymer trace
         at a given time
-    
+
     Returns
     ----------
     peak_asym: float
         scaled distance of the projection of the peak from the axis midpoint
     """
-    perp_distances, scaled_projections, _ = get_axis_distances_and_projections(fiber_points=fiber_points)
-    projection_of_peak = scaled_projections[perp_distances == np.max(perp_distances)]
-    peak_asym = np.max(projection_of_peak - 0.5)  # max kinda handles multiple peaks
+    (
+        perp_distances,
+        scaled_projections,
+        _,
+    ) = get_end_to_end_axis_distances_and_projections(
+        polymer_trace=polymer_trace
+    )
+    projection_of_peak = scaled_projections[
+        perp_distances == np.max(perp_distances)
+    ]
+    peak_asym = np.max(
+        projection_of_peak - 0.5
+    )  # max kinda handles multiple peaks
 
     return peak_asym
 
 
-def get_total_fiber_twist(fiber_points):
+def get_total_fiber_twist(
+    polymer_trace: np.ndarray,
+) -> float:
     """
-    Returns the sum of angles between consecutive vectors from fiber points
-    to the axis
-    
+    Returns the sum of angles between consecutive vectors from the
+    polymer trace points to the end-to-end axis
+
     Parameters
     ----------
-    fiber_points: [n x 3] numpy array
-        array containing the x,y,z positions of fiber points
+    polymer_trace: [n x 3] numpy array
+        array containing the x,y,z positions of the polymer trace
         at a given time
-    
+
     Returns
     ----------
     total_twist: float
-        sum of angles between vectors from fiber points to axis
+        sum of angles between vectors from trace points to axis
     """
-    _, _, projection_positions = get_axis_distances_and_projections(fiber_points=fiber_points)
-    perp_vectors = fiber_points - projection_positions
+    _, _, projection_positions = get_end_to_end_axis_distances_and_projections(
+        polymer_trace=polymer_trace
+    )
+    perp_vectors = polymer_trace - projection_positions
     perp_vectors = perp_vectors / np.linalg.norm(perp_vectors, axis=1)[:, None]
-    consecutive_angles = np.arccos(np.einsum('ij,ij->i', perp_vectors[1:], perp_vectors[:-1]))
+    consecutive_angles = np.arccos(
+        np.einsum("ij,ij->i", perp_vectors[1:], perp_vectors[:-1])
+    )
     total_twist = np.nansum(consecutive_angles)
 
     return total_twist

--- a/subcell_analysis/compression_analysis.py
+++ b/subcell_analysis/compression_analysis.py
@@ -55,6 +55,27 @@ def get_axis_distances_and_projections(fiber_points):
     return perp_distances, scaled_projections, projection_positions
 
 
+def get_average_distance_from_axis(fiber_points):
+    """
+    Returns the average perpendicular distance of fiber points from the axis
+    
+    Parameters
+    ----------
+    fiber_points: [n x 3] numpy array
+        array containing the x,y,z positions of fiber points
+        at a given time
+    
+    Returns
+    ----------
+    avg_perp_distance: float
+        average perpendicular distance of fiber points from the axis
+    """
+    perp_distances, _, _ = get_axis_distances_and_projections(fiber_points=fiber_points)
+    avg_perp_distance = np.nanmean(perp_distances)
+
+    return avg_perp_distance
+
+
 def get_asymmetry_of_peak(fiber_points):
     """
     returns the scaled distance of the projection of the peak from the axis midpoint

--- a/subcell_analysis/compression_analysis.py
+++ b/subcell_analysis/compression_analysis.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 import numpy as np
 import matplotlib as plt
-
-
+# TODO: consider creating a fiber class?
 
 
 def asymmetry(fibers_df):
@@ -19,3 +18,85 @@ def asymmetry(fibers_df):
         #print(diff[index])
     print(len(diff))
     #write 
+
+
+def get_axis_distances_and_projections(fiber_points):
+    """
+    Returns the distances of fiber points from the axis
+
+    Parameters
+    ----------
+    fiber_points: [n x 3] numpy array
+        array containing the x,y,z positions of fiber points
+        at a given time
+
+    Returns
+    ----------
+    perp_distances: [n x 1] numpy array
+        perpendicular distances of fiber points from the axis
+
+    scaled_projections: [n x 1] numpy array
+        length of fiber point projections along the axis, scaled
+        by axis length.
+        Can be negative.    
+    """
+    axis = fiber_points[-1] - fiber_points[0]
+    axis_length = np.linalg.norm(axis)
+
+    position_vectors = fiber_points - fiber_points[0]
+    dot_products = np.dot(position_vectors, axis)
+
+    projections = dot_products / axis_length
+    projection_positions = fiber_points[0] + projections[:, None] * axis / axis_length
+
+    perp_distances = np.linalg.norm(fiber_points - projection_positions, axis=1)
+    scaled_projections = projections / axis_length
+
+    return perp_distances, scaled_projections, projection_positions
+
+
+def get_asymmetry_of_peak(fiber_points):
+    """
+    returns the scaled distance of the projection of the peak from the axis midpoint
+    
+    Parameters
+    ----------
+    fiber_points: [n x 3] numpy array
+        array containing the x,y,z positions of fiber points
+        at a given time
+    
+    Returns
+    ----------
+    peak_asym: float
+        scaled distance of the projection of the peak from the axis midpoint
+    """
+    perp_distances, scaled_projections, _ = get_axis_distances_and_projections(fiber_points=fiber_points)
+    projection_of_peak = scaled_projections[perp_distances == np.max(perp_distances)]
+    peak_asym = np.max(projection_of_peak - 0.5)  # max kinda handles multiple peaks
+
+    return peak_asym
+
+
+def get_total_fiber_twist(fiber_points):
+    """
+    Returns the sum of angles between consecutive vectors from fiber points
+    to the axis
+    
+    Parameters
+    ----------
+    fiber_points: [n x 3] numpy array
+        array containing the x,y,z positions of fiber points
+        at a given time
+    
+    Returns
+    ----------
+    total_twist: float
+        sum of angles between vectors from fiber points to axis
+    """
+    _, _, projection_positions = get_axis_distances_and_projections(fiber_points=fiber_points)
+    perp_vectors = fiber_points - projection_positions
+    perp_vectors = perp_vectors / np.linalg.norm(perp_vectors, axis=1)[:, None]
+    consecutive_angles = np.arccos(np.einsum('ij,ij->i', perp_vectors[1:], perp_vectors[:-1]))
+    total_twist = np.nansum(consecutive_angles)
+
+    return total_twist


### PR DESCRIPTION
This PR adds base functions to calculate geometric measures for fibers denoted by an array of fiber points at a given time.

Utilities added:
1. Function to calculate distance of points from the axis, length of projection along the axis, and position of projected points

Measures added:
1. Average perpendicular distance from the axis
1. peak asymmetric distance: distance of projection of peak from midpoint
2. total fiber twist: sum of consecutive angles between projections from fiber points to the axis