### PR TITLE
Sub sample simulations

### DIFF
--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -95,8 +95,8 @@ df_readdy.to_csv(
 )
 
 # %% Load from saved data
-# df_readdy = pd.read_csv(f"{df_path}/readdy_actin
-# _compression_metrics_all_velocities_and_repeats.csv")
+df_cytosim = pd.read_csv(f"{df_path}/cytosim_actin_compression_subsampled.csv")
+df_readdy = pd.read_csv(f"{df_path}/readdy_actin_compression_subsampled.csv")
 
 # %% Plot metrics for readdy and cytosim
 figure_path = Path("../../figures")
@@ -139,3 +139,5 @@ for metric in metrics:
     fig.suptitle(f"{metric.value}")
     plt.tight_layout()
     fig.savefig(figure_path / f"all_simulators_{metric.value}_vs_time.png")
+
+# %%

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -11,112 +11,52 @@ from subcell_analysis.compression_workflow_runner import compression_metrics_wor
 # %% set matplotlib defaults
 plt.rcdefaults()
 
-# %% Set parameters
-readdy_compression_velocities = [4.7, 15, 47, 150]
-# cytosim_compression_velocities = [0.15, 0.47434165, 1.5,
-#  4.73413649, 15, 47.4341649, 150]
-cytosim_compression_velocities = [0.15, 0.47434165, 1.5, 4.7, 15, 47, 150]
-
 # %%
 metrics = [
     COMPRESSIONMETRIC.NON_COPLANARITY,
     COMPRESSIONMETRIC.PEAK_ASYMMETRY,
     COMPRESSIONMETRIC.TOTAL_FIBER_TWIST,
+    COMPRESSIONMETRIC.CALC_BENDING_ENERGY,
 ]
 
 # %% Process cytosim data
 df_path = Path("../data/dataframes")
 # %% metric options
 options = {
-    "signed": False,
+    "signed": True,
 }
-# %%
-num_repeats = 5
-velocity_inds = range(3, 7)
-df_metrics = []
-for index in velocity_inds:
-    for repeat in range(num_repeats):
-        print(
-            f"Calculating metrics for velocity "
-            f"{cytosim_compression_velocities[index]} and repeat {repeat}"
-        )
+# %% load dataframe
+df = pd.read_csv(df_path / "combined_actin_compression_dataset_subsampled.csv")
 
-        df = pd.read_csv(
-            f"{df_path}/cytosim_actin_compression_velocity_vary_"
-            f"compress_rate000{index}_repeat_{repeat}.csv"
-        )
-        df = compression_metrics_workflow(df, metrics, **options)  # type: ignore
-        metric_df = (
-            df.groupby("time")[[metric.value for metric in metrics]]
-            .mean()
-            .reset_index()
-        )
-        metric_df["velocity"] = cytosim_compression_velocities[index]
-        metric_df["repeat"] = repeat
-        df_metrics.append(metric_df)
-        # break
-    # break
-df_cytosim = pd.concat(df_metrics)
-df_cytosim.to_csv(
-    f"{df_path}/cytosim_actin_compression_metrics_all_velocities_and_repeats.csv"
+# %% add metrics
+for simulator, df_sim in df.groupby("simulator"):
+    for velocity, df_velocity in df_sim.groupby("velocity"):
+        for repeat, df_repeat in df_velocity.groupby("repeat"):
+            print(f"simulator: {simulator}, velocity: {velocity}, repeat: {repeat}")
+            df_repeat = compression_metrics_workflow(
+                df_repeat, metrics_to_calculate=metrics, **options
+            )
+            for metric in metrics:
+                df.loc[df_repeat.index, metric.value] = df_repeat[metric.value]
+# %% save dataframe
+df.to_csv(
+    f"{df_path}/combined_actin_compression_metrics_all_velocities_and_repeats_subsampled.csv"
 )
-
-# %% Load from saved data
-# df_cytosim = pd.read_csv(f"{df_path}/cytosim_actin_compression_
-# metrics_all_velocities_and_repeats.csv")
-
-# %% Process readdy data
-num_repeats = 3
-df_metrics = []
-for velocity in readdy_compression_velocities:
-    for repeat in range(num_repeats):
-        file_path = (
-            df_path
-            / f"readdy_actin_compression_velocity_{velocity}_repeat_{repeat}.csv"
-        )
-        if file_path.is_file():
-            df = pd.read_csv(file_path)
-        else:
-            continue
-        print(f"Calculating metrics for velocity {velocity} and repeat {repeat}")
-        df = compression_metrics_workflow(df, metrics, **options)  # type: ignore
-        metric_df = (
-            df.groupby("time")[[metric.value for metric in metrics]]
-            .mean()
-            .reset_index()
-        )
-        metric_df["velocity"] = velocity
-        metric_df["repeat"] = repeat
-        df_metrics.append(metric_df)
-
-df_readdy = pd.concat(df_metrics)
-df_readdy.to_csv(
-    f"{df_path}/readdy_actin_compression_metrics_all_velocities_and_repeats.csv"
-)
-
-# %% Load from saved data
-# df_readdy = pd.read_csv(f"{df_path}/readdy_actin
-# _compression_metrics_all_velocities_and_repeats.csv")
 
 # %% Plot metrics for readdy and cytosim
 figure_path = Path("../../figures")
 figure_path.mkdir(exist_ok=True)
-# %%
-df_cytosim["simulator"] = "cytosim"
-df_readdy["simulator"] = "readdy"
-
-df_combined = pd.concat([df_cytosim, df_readdy])
 
 # %%
 color_map = {"cytosim": "C0", "readdy": "C1"}
 
 # %% plot metrics vs time
-num_velocities = df_combined["velocity"].nunique()
+num_velocities = df["velocity"].nunique()
 for metric in metrics:
     fig, axs = plt.subplots(
         1, num_velocities, figsize=(num_velocities * 5, 5), sharey=True, dpi=300
     )
-    for ct, (velocity, df_velocity) in enumerate(df_combined.groupby("velocity")):
+    for ct, (velocity, df_velocity) in enumerate(df.groupby("velocity")):
         for simulator, df_simulator in df_velocity.groupby("simulator"):
             for repeat, df_repeat in df_simulator.groupby("repeat"):
                 if repeat == 0:
@@ -124,9 +64,9 @@ for metric in metrics:
                 else:
                     label = "_nolegend_"
                 axs[ct].plot(
-                    np.linspace(0, 1, len(df_repeat)),
+                    np.linspace(0, 1, df_repeat["time"].nunique()),
                     # df_repeat["time"] * time_scale,
-                    df_repeat[metric.value],
+                    df_repeat.groupby("time")[metric.value].mean(),
                     label=label,
                     color=color_map[simulator],
                     alpha=0.7,
@@ -138,4 +78,6 @@ for metric in metrics:
     fig.supxlabel("Normalized time")
     fig.suptitle(f"{metric.value}")
     plt.tight_layout()
-    fig.savefig(figure_path / f"all_simulators_{metric.value}_vs_time.png")
+    fig.savefig(figure_path / f"all_simulators_{metric.value}_vs_time_subsampled.png")
+
+# %%

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -44,10 +44,6 @@ df.to_csv(
     f"{df_path}/combined_actin_compression_metrics_all_velocities_and_repeats_subsampled.csv"
 )
 
-# %% Load from saved data
-df_cytosim = pd.read_csv(f"{df_path}/cytosim_actin_compression_subsampled.csv")
-df_readdy = pd.read_csv(f"{df_path}/readdy_actin_compression_subsampled.csv")
-
 # %% Plot metrics for readdy and cytosim
 figure_path = Path("../../figures")
 figure_path.mkdir(exist_ok=True)
@@ -88,3 +84,5 @@ for metric in metrics:
     fig.suptitle(f"{metric.value}")
     plt.tight_layout()
     fig.savefig(figure_path / f"all_simulators_{metric.value}_vs_time_subsampled.png")
+
+# %%

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -17,7 +17,7 @@ metrics = [
     COMPRESSIONMETRIC.PEAK_ASYMMETRY,
     COMPRESSIONMETRIC.TOTAL_FIBER_TWIST,
     COMPRESSIONMETRIC.CALC_BENDING_ENERGY,
-    COMPRESSIONMETRIC.SPLINE_DISTANCE,
+    COMPRESSIONMETRIC.CONTOUR_LENGTH,
 ]
 
 # %% Process cytosim data
@@ -42,39 +42,6 @@ for simulator, df_sim in df.groupby("simulator"):
 # %% save dataframe
 df.to_csv(
     f"{df_path}/combined_actin_compression_metrics_all_velocities_and_repeats_subsampled.csv"
-)
-
-# %% Load from saved data
-# df_cytosim = pd.read_csv(f"{df_path}/cytosim_actin_compression_
-# metrics_all_velocities_and_repeats.csv")
-
-# %% Process readdy data
-num_repeats = 3
-df_metrics = []
-for velocity in readdy_compression_velocities:
-    for repeat in range(num_repeats):
-        file_path = (
-            df_path
-            / f"readdy_actin_compression_velocity_{velocity}_repeat_{repeat}.csv"
-        )
-        if file_path.is_file():
-            df = pd.read_csv(file_path)
-        else:
-            continue
-        print(f"Calculating metrics for velocity {velocity} and repeat {repeat}")
-        df = compression_metrics_workflow(df, metrics, **options)  # type: ignore
-        metric_df = (
-            df.groupby("time")[[metric.value for metric in metrics]]
-            .mean()
-            .reset_index()
-        )
-        metric_df["velocity"] = velocity
-        metric_df["repeat"] = repeat
-        df_metrics.append(metric_df)
-
-df_readdy = pd.concat(df_metrics)
-df_readdy.to_csv(
-    f"{df_path}/readdy_actin_compression_metrics_all_velocities_and_repeats.csv"
 )
 
 # %% Load from saved data
@@ -103,7 +70,7 @@ for metric in metrics:
                     label = "_nolegend_"
                 xvals = np.linspace(0, 1, df_repeat["time"].nunique())
                 yvals = df_repeat.groupby("time")[metric.value].mean()
-                if simulator == "cytosim" and metric.value == "SPLINE_DISTANCE":
+                if simulator == "cytosim" and metric.value == "CONTOUR_LENGTH":
                     yvals = yvals * 1000
                 axs[ct].plot(
                     xvals,
@@ -121,7 +88,3 @@ for metric in metrics:
     fig.suptitle(f"{metric.value}")
     plt.tight_layout()
     fig.savefig(figure_path / f"all_simulators_{metric.value}_vs_time_subsampled.png")
-
-# %%
-
-# %%

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -15,6 +15,7 @@ plt.rcdefaults()
 metrics = [
     COMPRESSIONMETRIC.NON_COPLANARITY,
     COMPRESSIONMETRIC.PEAK_ASYMMETRY,
+    COMPRESSIONMETRIC.AVERAGE_PERP_DISTANCE,
     COMPRESSIONMETRIC.TOTAL_FIBER_TWIST,
     COMPRESSIONMETRIC.CALC_BENDING_ENERGY,
     COMPRESSIONMETRIC.CONTOUR_LENGTH,
@@ -66,7 +67,7 @@ for metric in metrics:
                     label = "_nolegend_"
                 xvals = np.linspace(0, 1, df_repeat["time"].nunique())
                 yvals = df_repeat.groupby("time")[metric.value].mean()
-                if simulator == "cytosim" and metric.value == "CONTOUR_LENGTH":
+                if simulator == "cytosim" and metric.value in ["CONTOUR_LENGTH", "AVERAGE_PERP_DISTANCE"]:
                     yvals = yvals * 1000
                 axs[ct].plot(
                     xvals,

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -17,6 +17,7 @@ metrics = [
     COMPRESSIONMETRIC.PEAK_ASYMMETRY,
     COMPRESSIONMETRIC.TOTAL_FIBER_TWIST,
     COMPRESSIONMETRIC.CALC_BENDING_ENERGY,
+    COMPRESSIONMETRIC.SPLINE_DISTANCE,
 ]
 
 # %% Process cytosim data
@@ -63,10 +64,14 @@ for metric in metrics:
                     label = f"{simulator}"
                 else:
                     label = "_nolegend_"
+                xvals = np.linspace(0, 1, df_repeat["time"].nunique())
+                yvals = df_repeat.groupby("time")[metric.value].mean()
+                if simulator == "cytosim" and metric.value == "SPLINE_DISTANCE":
+                    yvals = yvals * 1000
                 axs[ct].plot(
-                    np.linspace(0, 1, df_repeat["time"].nunique()),
+                    xvals,
                     # df_repeat["time"] * time_scale,
-                    df_repeat.groupby("time")[metric.value].mean(),
+                    yvals,
                     label=label,
                     color=color_map[simulator],
                     alpha=0.7,

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -67,7 +67,10 @@ for metric in metrics:
                     label = "_nolegend_"
                 xvals = np.linspace(0, 1, df_repeat["time"].nunique())
                 yvals = df_repeat.groupby("time")[metric.value].mean()
-                if simulator == "cytosim" and metric.value in ["CONTOUR_LENGTH", "AVERAGE_PERP_DISTANCE"]:
+                if simulator == "cytosim" and metric.value in [
+                    "CONTOUR_LENGTH",
+                    "AVERAGE_PERP_DISTANCE",
+                ]:
                     yvals = yvals * 1000
                 axs[ct].plot(
                     xvals,

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -54,6 +54,7 @@ color_map = {"cytosim": "C0", "readdy": "C1"}
 
 # %% plot metrics vs time
 num_velocities = df["velocity"].nunique()
+compression_distance = 0.3  # um
 for metric in metrics:
     fig, axs = plt.subplots(
         1, num_velocities, figsize=(num_velocities * 5, 5), sharey=True, dpi=300
@@ -65,7 +66,8 @@ for metric in metrics:
                     label = f"{simulator}"
                 else:
                     label = "_nolegend_"
-                xvals = np.linspace(0, 1, df_repeat["time"].nunique())
+                total_time = compression_distance / velocity  # s
+                xvals = np.linspace(0, 1, df_repeat["time"].nunique()) * total_time
                 yvals = df_repeat.groupby("time")[metric.value].mean()
                 if simulator == "cytosim" and metric.value in [
                     "CONTOUR_LENGTH",
@@ -80,11 +82,12 @@ for metric in metrics:
                     color=color_map[simulator],
                     alpha=0.7,
                 )
+                plt.setp(axs[ct].get_xticklabels(), rotation=30, horizontalalignment='right')
         axs[ct].legend()
         axs[ct].set_title(f"Velocity: {velocity}")
         if ct == 0:
             axs[ct].set_ylabel(metric.value)
-    fig.supxlabel("Normalized time")
+    fig.supxlabel(R"Time ($\mu$s)")
     fig.suptitle(f"{metric.value}")
     plt.tight_layout()
     fig.savefig(figure_path / f"all_simulators_{metric.value}_vs_time_subsampled.png")

--- a/notebooks/sub_sample_simulations.py
+++ b/notebooks/sub_sample_simulations.py
@@ -60,7 +60,7 @@ for index, df in enumerate(dfs):
                 df_subsample_list[index].append(df_tmp)
 
     df_subsampled[index] = pd.concat(df_subsample_list[index])
-    # %%
+# %%
 df_subsampled[0].to_csv(
     df_folder / "cytosim_actin_compression_subsampled.csv", index=False
 )

--- a/notebooks/sub_sample_simulations.py
+++ b/notebooks/sub_sample_simulations.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 import matplotlib.pyplot as plt
+
 # %% load dataframes
 df_folder = Path("../data/dataframes")
 # %%
@@ -24,56 +25,59 @@ cols_to_interp = ["xpos", "ypos", "zpos"]
 # Here we will loop over df for readdy and cytosim, so that you can run the script from start to end
 # and it will subsample both the cytosim and readdy data
 
-
-df = readdy_df
-df_subsample_list = []
+dfs = [cytosim_df, readdy_df]
+df_subsample_list = [[], []]
+df_subsampled = [[], []]
 # %%
-for velocity, df_velocity in df.groupby("velocity"):
-    for repeat, df_repeat in df_velocity.groupby("repeat"):
-        num_time_vals = df_repeat["time"].nunique()
-        df_time_vals = df_repeat["time"].unique()
-        time_inds = np.rint(
-            np.interp(
-                np.linspace(0, 1, n_timepoints),
-                np.linspace(0, 1, num_time_vals),
-                np.arange(num_time_vals),
-            )
-        )
-        use_time_vals = df_time_vals[time_inds.astype(int)]
-        for time, df_time in df_repeat.groupby("time"):
-            if time not in use_time_vals:
-                continue
-            print(
-                f"velocity: {velocity}, repeat: {repeat}, time: {time}"
-            )
-            df_tmp = pd.DataFrame()
-            df_tmp["monomer_ids"] = np.arange(n_monomer_points)
-            df_tmp["time"] = time
-            df_tmp["velocity"] = velocity
-            df_tmp["repeat"] = repeat
-            for col in cols_to_interp:
-                df_tmp[col] = np.interp(
-                    np.linspace(0, 1, n_monomer_points),
-                    np.linspace(0, 1, df_time.shape[0]),
-                    df_time[col].values,
+for index, df in enumerate(dfs):
+    for velocity, df_velocity in df.groupby("velocity"):
+        for repeat, df_repeat in df_velocity.groupby("repeat"):
+            num_time_vals = df_repeat["time"].nunique()
+            df_time_vals = df_repeat["time"].unique()
+            time_inds = np.rint(
+                np.interp(
+                    np.linspace(0, 1, n_timepoints),
+                    np.linspace(0, 1, num_time_vals),
+                    np.arange(num_time_vals),
                 )
-            df_subsample_list.append(df_tmp)
+            )
+            use_time_vals = df_time_vals[time_inds.astype(int)]
+            for time, df_time in df_repeat.groupby("time"):
+                if time not in use_time_vals:
+                    continue
+                print(f"velocity: {velocity}, repeat: {repeat}, time: {time}")
+                df_tmp = pd.DataFrame()
+                df_tmp["monomer_ids"] = np.arange(n_monomer_points)
+                df_tmp["time"] = time
+                df_tmp["velocity"] = velocity
+                df_tmp["repeat"] = repeat
+                for col in cols_to_interp:
+                    df_tmp[col] = np.interp(
+                        np.linspace(0, 1, n_monomer_points),
+                        np.linspace(0, 1, df_time.shape[0]),
+                        df_time[col].values,
+                    )
+                df_subsample_list[index].append(df_tmp)
 
-df_subsampled = pd.concat(df_subsample_list)
-# %% 
-df_subsampled.to_csv(df_folder / "readdy_actin_compression_subsampled.csv", index=False)
-# %% get df for given velocity and repeat
-velocity_vals = df_subsampled["velocity"].unique()
-repeat_vals = df_subsampled["repeat"].unique()
-print(
-    f"velocity_vals: {velocity_vals}, repeat_vals: {repeat_vals}"
+    df_subsampled[index] = pd.concat(df_subsample_list[index])
+    # %%
+df_subsampled[0].to_csv(
+    df_folder / "cytosim_actin_compression_subsampled.csv", index=False
 )
+df_subsampled[1].to_csv(
+    df_folder / "readdy_actin_compression_subsampled.csv", index=False
+)
+# %% get df for given velocity and repeat
+cytosim_subsampled = df_subsampled[0]
+velocity_vals = cytosim_subsampled["velocity"].unique()
+repeat_vals = cytosim_subsampled["repeat"].unique()
+print(f"velocity_vals: {velocity_vals}, repeat_vals: {repeat_vals}")
 # %%
 velocity_ind = 0
 repeat_ind = 0
-df_test = df_subsampled[
-    (df_subsampled["velocity"] == velocity_vals[velocity_ind])
-    & (df_subsampled["repeat"] == repeat_vals[repeat_ind])
+df_test = cytosim_subsampled[
+    (cytosim_subsampled["velocity"] == velocity_vals[velocity_ind])
+    & (cytosim_subsampled["repeat"] == repeat_vals[repeat_ind])
 ]
 
 # %%
@@ -83,3 +87,4 @@ axs[1].plot(df_time["xpos"], df_time["ypos"], "ko-", ms=3, label="original")
 # axs[1].set_xlim([-0.1,-0.05 ])
 # ax.legend()
 plt.show()
+# %%

--- a/notebooks/sub_sample_simulations.py
+++ b/notebooks/sub_sample_simulations.py
@@ -1,0 +1,85 @@
+# %% imports
+import numpy as np
+import pandas as pd
+from pathlib import Path
+import matplotlib.pyplot as plt
+# %% load dataframes
+df_folder = Path("../data/dataframes")
+# %%
+cytosim_df = pd.read_csv(
+    df_folder / "cytosim_actin_compression_all_velocities_and_repeats.csv"
+)
+readdy_df = pd.read_csv(
+    df_folder / "readdy_actin_compression_all_velocities_and_repeats.csv"
+)
+print(cytosim_df.shape)
+print(readdy_df.shape)
+
+# %%
+n_timepoints = 200
+n_monomer_points = 200
+# %%
+cols_to_interp = ["xpos", "ypos", "zpos"]
+# %%
+# Here we will loop over df for readdy and cytosim, so that you can run the script from start to end
+# and it will subsample both the cytosim and readdy data
+
+
+df = readdy_df
+df_subsample_list = []
+# %%
+for velocity, df_velocity in df.groupby("velocity"):
+    for repeat, df_repeat in df_velocity.groupby("repeat"):
+        num_time_vals = df_repeat["time"].nunique()
+        df_time_vals = df_repeat["time"].unique()
+        time_inds = np.rint(
+            np.interp(
+                np.linspace(0, 1, n_timepoints),
+                np.linspace(0, 1, num_time_vals),
+                np.arange(num_time_vals),
+            )
+        )
+        use_time_vals = df_time_vals[time_inds.astype(int)]
+        for time, df_time in df_repeat.groupby("time"):
+            if time not in use_time_vals:
+                continue
+            print(
+                f"velocity: {velocity}, repeat: {repeat}, time: {time}"
+            )
+            df_tmp = pd.DataFrame()
+            df_tmp["monomer_ids"] = np.arange(n_monomer_points)
+            df_tmp["time"] = time
+            df_tmp["velocity"] = velocity
+            df_tmp["repeat"] = repeat
+            for col in cols_to_interp:
+                df_tmp[col] = np.interp(
+                    np.linspace(0, 1, n_monomer_points),
+                    np.linspace(0, 1, df_time.shape[0]),
+                    df_time[col].values,
+                )
+            df_subsample_list.append(df_tmp)
+
+df_subsampled = pd.concat(df_subsample_list)
+# %% 
+df_subsampled.to_csv(df_folder / "readdy_actin_compression_subsampled.csv", index=False)
+# %% get df for given velocity and repeat
+velocity_vals = df_subsampled["velocity"].unique()
+repeat_vals = df_subsampled["repeat"].unique()
+print(
+    f"velocity_vals: {velocity_vals}, repeat_vals: {repeat_vals}"
+)
+# %%
+velocity_ind = 0
+repeat_ind = 0
+df_test = df_subsampled[
+    (df_subsampled["velocity"] == velocity_vals[velocity_ind])
+    & (df_subsampled["repeat"] == repeat_vals[repeat_ind])
+]
+
+# %%
+fig, axs = plt.subplots(2, 1, sharex=True)
+axs[0].plot(df_tmp["xpos"], df_tmp["ypos"], "ro-", ms=3, label="subsampled")
+axs[1].plot(df_time["xpos"], df_time["ypos"], "ko-", ms=3, label="original")
+# axs[1].set_xlim([-0.1,-0.05 ])
+# ax.legend()
+plt.show()

--- a/subcell_analysis/compression_analysis.py
+++ b/subcell_analysis/compression_analysis.py
@@ -19,7 +19,7 @@ class COMPRESSIONMETRIC(Enum):
     TOTAL_FIBER_TWIST = "TOTAL_FIBER_TWIST"
     ENERGY_ASYMMETRY = "ENERGY_ASYMMETRY"
     CALC_BENDING_ENERGY = "CALC_BENDING_ENERGY"
-    SPLINE_DISTANCE = "SPLINE_DISTANCE"
+    CONTOUR_LENGTH = "CONTOUR_LENGTH"
 
 
 def get_end_to_end_unit_vector(
@@ -188,7 +188,7 @@ def get_pca_polymer_trace_projection(
     return pca.transform(polymer_trace)
 
 
-def get_spline_distance_from_trace(
+def get_contour_length_from_trace(
     polymer_trace: np.ndarray,
     **options: dict,
 ) -> float:

--- a/subcell_analysis/compression_analysis.py
+++ b/subcell_analysis/compression_analysis.py
@@ -19,6 +19,7 @@ class COMPRESSIONMETRIC(Enum):
     TOTAL_FIBER_TWIST = "TOTAL_FIBER_TWIST"
     ENERGY_ASYMMETRY = "ENERGY_ASYMMETRY"
     CALC_BENDING_ENERGY = "CALC_BENDING_ENERGY"
+    SPLINE_DISTANCE = "SPLINE_DISTANCE"
 
 
 def get_end_to_end_unit_vector(
@@ -185,6 +186,31 @@ def get_pca_polymer_trace_projection(
     """
     pca = fit_pca_to_polymer_trace(polymer_trace=polymer_trace)
     return pca.transform(polymer_trace)
+
+
+def get_spline_distance_from_trace(
+    polymer_trace: np.ndarray,
+    **options: dict,
+) -> float:
+    """
+    Returns the sum of inter-monomer distances in the trace
+
+    Parameters
+    ----------
+    polymer_trace: [n x 3] numpy array
+        array containing the x,y,z positions of the polymer trace
+    **options: dict
+        Additional options as key-value pairs.
+
+    Returns
+    ----------
+    total_distance: float
+        sum of inter-monomer distances in the trace
+    """
+    total_distance = 0
+    for i in range(len(polymer_trace) - 1):
+        total_distance += np.linalg.norm(polymer_trace[i] - polymer_trace[i + 1])
+    return total_distance
 
 
 def get_bending_energy_from_trace(

--- a/subcell_analysis/compression_analysis.py
+++ b/subcell_analysis/compression_analysis.py
@@ -193,7 +193,7 @@ def get_contour_length_from_trace(
     **options: dict,
 ) -> float:
     """
-    Returns the sum of inter-monomer distances in the trace
+    Returns the sum of inter-monomer distances in the trace.
 
     Parameters
     ----------
@@ -203,7 +203,7 @@ def get_contour_length_from_trace(
         Additional options as key-value pairs.
 
     Returns
-    ----------
+    -------
     total_distance: float
         sum of inter-monomer distances in the trace
     """
@@ -281,7 +281,9 @@ def get_total_fiber_twist(
     ]
     trace_2d = trace_2d - np.mean(trace_2d, axis=0)
 
-    return get_total_fiber_twist_2d(trace_2d, signed=signed, tolerance=tolerance)
+    return get_total_fiber_twist_2d(
+        trace_2d, signed=signed, tolerance=tolerance  # type: ignore
+    )
 
 
 def get_total_fiber_twist_pca(

--- a/subcell_analysis/compression_workflow_runner.py
+++ b/subcell_analysis/compression_workflow_runner.py
@@ -11,7 +11,7 @@ from .compression_analysis import (
     get_third_component_variance,
     get_total_fiber_twist,
     get_bending_energy_from_trace,
-    get_spline_distance_from_trace,
+    get_contour_length_from_trace,
 )
 
 ABS_TOL = 1e-6
@@ -81,11 +81,11 @@ def run_metric_calculation(
                 **options,
             )
 
-        if metric == COMPRESSIONMETRIC.SPLINE_DISTANCE:
+        if metric == COMPRESSIONMETRIC.CONTOUR_LENGTH:
             polymer_trace = fiber_at_time[["xpos", "ypos", "zpos"]].values
             all_points.loc[
                 fiber_at_time.index, metric.value
-            ] = get_spline_distance_from_trace(polymer_trace, **options)
+            ] = get_contour_length_from_trace(polymer_trace, **options)
 
         if metric == COMPRESSIONMETRIC.SUM_BENDING_ENERGY:
             polymer_trace = fiber_at_time[

--- a/subcell_analysis/compression_workflow_runner.py
+++ b/subcell_analysis/compression_workflow_runner.py
@@ -6,12 +6,12 @@ from .compression_analysis import (
     COMPRESSIONMETRIC,
     get_asymmetry_of_peak,
     get_average_distance_from_end_to_end_axis,
+    get_bending_energy_from_trace,
+    get_contour_length_from_trace,
     get_energy_asymmetry,
     get_sum_bending_energy,
     get_third_component_variance,
     get_total_fiber_twist,
-    get_bending_energy_from_trace,
-    get_contour_length_from_trace,
 )
 
 ABS_TOL = 1e-6

--- a/subcell_analysis/compression_workflow_runner.py
+++ b/subcell_analysis/compression_workflow_runner.py
@@ -11,6 +11,7 @@ from .compression_analysis import (
     get_third_component_variance,
     get_total_fiber_twist,
     get_bending_energy_from_trace,
+    get_spline_distance_from_trace,
 )
 
 ABS_TOL = 1e-6
@@ -79,6 +80,12 @@ def run_metric_calculation(
                 polymer_trace,
                 **options,
             )
+
+        if metric == COMPRESSIONMETRIC.SPLINE_DISTANCE:
+            polymer_trace = fiber_at_time[["xpos", "ypos", "zpos"]].values
+            all_points.loc[
+                fiber_at_time.index, metric.value
+            ] = get_spline_distance_from_trace(polymer_trace, **options)
 
         if metric == COMPRESSIONMETRIC.SUM_BENDING_ENERGY:
             polymer_trace = fiber_at_time[

--- a/subcell_analysis/compression_workflow_runner.py
+++ b/subcell_analysis/compression_workflow_runner.py
@@ -10,6 +10,7 @@ from .compression_analysis import (
     get_sum_bending_energy,
     get_third_component_variance,
     get_total_fiber_twist,
+    get_bending_energy_from_trace,
 )
 
 ABS_TOL = 1e-6
@@ -67,9 +68,6 @@ def run_metric_calculation(
             polymer_trace = fiber_at_time[["xpos", "ypos", "zpos"]].values
             all_points.loc[fiber_at_time.index, metric.value] = get_total_fiber_twist(
                 polymer_trace,
-                compression_axis=0,
-                signed=True,
-                tolerance=ABS_TOL,
                 **options,
             )
 
@@ -89,6 +87,13 @@ def run_metric_calculation(
             all_points.loc[fiber_at_time.index, metric.value] = get_sum_bending_energy(
                 polymer_trace, **options
             )
+
+        if metric == COMPRESSIONMETRIC.CALC_BENDING_ENERGY:
+            polymer_trace = fiber_at_time[["xpos", "ypos", "zpos"]].values
+            all_points.loc[
+                fiber_at_time.index, metric.value
+            ] = get_bending_energy_from_trace(polymer_trace, **options)
+
     return all_points
 
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #13 

### Description of Changes

Added a script to sub sample dataframe of x, y, z positions of fibers to a given number of time steps and monomer points. 

Run `notebooks/sub_sample_simulations.py` to create and save sub sampled dataframes. 