### PR TITLE
Postprocessing/create combined dataframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,7 +115,6 @@ ENV/
 
 # data files
 *.csv
-**/data/**
-**/figures/**
+data/**
+figures/**
 **/outputs/**
-**/figures/**

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -95,8 +95,8 @@ df_readdy.to_csv(
 )
 
 # %% Load from saved data
-# df_readdy = pd.read_csv(f"{df_path}/readdy_actin
-# _compression_metrics_all_velocities_and_repeats.csv")
+df_cytosim = pd.read_csv(f"{df_path}/cytosim_actin_compression_subsampled.csv")
+df_readdy = pd.read_csv(f"{df_path}/readdy_actin_compression_subsampled.csv")
 
 # %% Plot metrics for readdy and cytosim
 figure_path = Path("../../figures")
@@ -139,3 +139,5 @@ for metric in metrics:
     fig.suptitle(f"{metric.value}")
     plt.tight_layout()
     fig.savefig(figure_path / f"all_simulators_{metric.value}_vs_time.png")
+
+# %%

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -11,112 +11,52 @@ from subcell_analysis.compression_workflow_runner import compression_metrics_wor
 # %% set matplotlib defaults
 plt.rcdefaults()
 
-# %% Set parameters
-readdy_compression_velocities = [4.7, 15, 47, 150]
-# cytosim_compression_velocities = [0.15, 0.47434165, 1.5,
-#  4.73413649, 15, 47.4341649, 150]
-cytosim_compression_velocities = [0.15, 0.47434165, 1.5, 4.7, 15, 47, 150]
-
 # %%
 metrics = [
     COMPRESSIONMETRIC.NON_COPLANARITY,
     COMPRESSIONMETRIC.PEAK_ASYMMETRY,
     COMPRESSIONMETRIC.TOTAL_FIBER_TWIST,
+    COMPRESSIONMETRIC.CALC_BENDING_ENERGY,
 ]
 
 # %% Process cytosim data
 df_path = Path("../data/dataframes")
 # %% metric options
 options = {
-    "signed": False,
+    "signed": True,
 }
-# %%
-num_repeats = 5
-velocity_inds = range(3, 7)
-df_metrics = []
-for index in velocity_inds:
-    for repeat in range(num_repeats):
-        print(
-            f"Calculating metrics for velocity "
-            f"{cytosim_compression_velocities[index]} and repeat {repeat}"
-        )
+# %% load dataframe
+df = pd.read_csv(df_path / "combined_actin_compression_dataset_subsampled.csv")
 
-        df = pd.read_csv(
-            f"{df_path}/cytosim_actin_compression_velocity_vary_"
-            f"compress_rate000{index}_repeat_{repeat}.csv"
-        )
-        df = compression_metrics_workflow(df, metrics, **options)  # type: ignore
-        metric_df = (
-            df.groupby("time")[[metric.value for metric in metrics]]
-            .mean()
-            .reset_index()
-        )
-        metric_df["velocity"] = cytosim_compression_velocities[index]
-        metric_df["repeat"] = repeat
-        df_metrics.append(metric_df)
-        # break
-    # break
-df_cytosim = pd.concat(df_metrics)
-df_cytosim.to_csv(
-    f"{df_path}/cytosim_actin_compression_metrics_all_velocities_and_repeats.csv"
+# %% add metrics
+for simulator, df_sim in df.groupby("simulator"):
+    for velocity, df_velocity in df_sim.groupby("velocity"):
+        for repeat, df_repeat in df_velocity.groupby("repeat"):
+            print(f"simulator: {simulator}, velocity: {velocity}, repeat: {repeat}")
+            df_repeat = compression_metrics_workflow(
+                df_repeat, metrics_to_calculate=metrics, **options
+            )
+            for metric in metrics:
+                df.loc[df_repeat.index, metric.value] = df_repeat[metric.value]
+# %% save dataframe
+df.to_csv(
+    f"{df_path}/combined_actin_compression_metrics_all_velocities_and_repeats_subsampled.csv"
 )
-
-# %% Load from saved data
-# df_cytosim = pd.read_csv(f"{df_path}/cytosim_actin_compression_
-# metrics_all_velocities_and_repeats.csv")
-
-# %% Process readdy data
-num_repeats = 3
-df_metrics = []
-for velocity in readdy_compression_velocities:
-    for repeat in range(num_repeats):
-        file_path = (
-            df_path
-            / f"readdy_actin_compression_velocity_{velocity}_repeat_{repeat}.csv"
-        )
-        if file_path.is_file():
-            df = pd.read_csv(file_path)
-        else:
-            continue
-        print(f"Calculating metrics for velocity {velocity} and repeat {repeat}")
-        df = compression_metrics_workflow(df, metrics, **options)  # type: ignore
-        metric_df = (
-            df.groupby("time")[[metric.value for metric in metrics]]
-            .mean()
-            .reset_index()
-        )
-        metric_df["velocity"] = velocity
-        metric_df["repeat"] = repeat
-        df_metrics.append(metric_df)
-
-df_readdy = pd.concat(df_metrics)
-df_readdy.to_csv(
-    f"{df_path}/readdy_actin_compression_metrics_all_velocities_and_repeats.csv"
-)
-
-# %% Load from saved data
-# df_readdy = pd.read_csv(f"{df_path}/readdy_actin
-# _compression_metrics_all_velocities_and_repeats.csv")
 
 # %% Plot metrics for readdy and cytosim
 figure_path = Path("../../figures")
 figure_path.mkdir(exist_ok=True)
-# %%
-df_cytosim["simulator"] = "cytosim"
-df_readdy["simulator"] = "readdy"
-
-df_combined = pd.concat([df_cytosim, df_readdy])
 
 # %%
 color_map = {"cytosim": "C0", "readdy": "C1"}
 
 # %% plot metrics vs time
-num_velocities = df_combined["velocity"].nunique()
+num_velocities = df["velocity"].nunique()
 for metric in metrics:
     fig, axs = plt.subplots(
         1, num_velocities, figsize=(num_velocities * 5, 5), sharey=True, dpi=300
     )
-    for ct, (velocity, df_velocity) in enumerate(df_combined.groupby("velocity")):
+    for ct, (velocity, df_velocity) in enumerate(df.groupby("velocity")):
         for simulator, df_simulator in df_velocity.groupby("simulator"):
             for repeat, df_repeat in df_simulator.groupby("repeat"):
                 if repeat == 0:
@@ -124,9 +64,9 @@ for metric in metrics:
                 else:
                     label = "_nolegend_"
                 axs[ct].plot(
-                    np.linspace(0, 1, len(df_repeat)),
+                    np.linspace(0, 1, df_repeat["time"].nunique()),
                     # df_repeat["time"] * time_scale,
-                    df_repeat[metric.value],
+                    df_repeat.groupby("time")[metric.value].mean(),
                     label=label,
                     color=color_map[simulator],
                     alpha=0.7,
@@ -138,4 +78,6 @@ for metric in metrics:
     fig.supxlabel("Normalized time")
     fig.suptitle(f"{metric.value}")
     plt.tight_layout()
-    fig.savefig(figure_path / f"all_simulators_{metric.value}_vs_time.png")
+    fig.savefig(figure_path / f"all_simulators_{metric.value}_vs_time_subsampled.png")
+
+# %%

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -44,10 +44,6 @@ df.to_csv(
     f"{df_path}/combined_actin_compression_metrics_all_velocities_and_repeats_subsampled.csv"
 )
 
-# %% Load from saved data
-df_cytosim = pd.read_csv(f"{df_path}/cytosim_actin_compression_subsampled.csv")
-df_readdy = pd.read_csv(f"{df_path}/readdy_actin_compression_subsampled.csv")
-
 # %% Plot metrics for readdy and cytosim
 figure_path = Path("../../figures")
 figure_path.mkdir(exist_ok=True)
@@ -88,3 +84,5 @@ for metric in metrics:
     fig.suptitle(f"{metric.value}")
     plt.tight_layout()
     fig.savefig(figure_path / f"all_simulators_{metric.value}_vs_time_subsampled.png")
+
+# %%

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -17,7 +17,7 @@ metrics = [
     COMPRESSIONMETRIC.PEAK_ASYMMETRY,
     COMPRESSIONMETRIC.TOTAL_FIBER_TWIST,
     COMPRESSIONMETRIC.CALC_BENDING_ENERGY,
-    COMPRESSIONMETRIC.SPLINE_DISTANCE,
+    COMPRESSIONMETRIC.CONTOUR_LENGTH,
 ]
 
 # %% Process cytosim data
@@ -42,39 +42,6 @@ for simulator, df_sim in df.groupby("simulator"):
 # %% save dataframe
 df.to_csv(
     f"{df_path}/combined_actin_compression_metrics_all_velocities_and_repeats_subsampled.csv"
-)
-
-# %% Load from saved data
-# df_cytosim = pd.read_csv(f"{df_path}/cytosim_actin_compression_
-# metrics_all_velocities_and_repeats.csv")
-
-# %% Process readdy data
-num_repeats = 3
-df_metrics = []
-for velocity in readdy_compression_velocities:
-    for repeat in range(num_repeats):
-        file_path = (
-            df_path
-            / f"readdy_actin_compression_velocity_{velocity}_repeat_{repeat}.csv"
-        )
-        if file_path.is_file():
-            df = pd.read_csv(file_path)
-        else:
-            continue
-        print(f"Calculating metrics for velocity {velocity} and repeat {repeat}")
-        df = compression_metrics_workflow(df, metrics, **options)  # type: ignore
-        metric_df = (
-            df.groupby("time")[[metric.value for metric in metrics]]
-            .mean()
-            .reset_index()
-        )
-        metric_df["velocity"] = velocity
-        metric_df["repeat"] = repeat
-        df_metrics.append(metric_df)
-
-df_readdy = pd.concat(df_metrics)
-df_readdy.to_csv(
-    f"{df_path}/readdy_actin_compression_metrics_all_velocities_and_repeats.csv"
 )
 
 # %% Load from saved data
@@ -103,7 +70,7 @@ for metric in metrics:
                     label = "_nolegend_"
                 xvals = np.linspace(0, 1, df_repeat["time"].nunique())
                 yvals = df_repeat.groupby("time")[metric.value].mean()
-                if simulator == "cytosim" and metric.value == "SPLINE_DISTANCE":
+                if simulator == "cytosim" and metric.value == "CONTOUR_LENGTH":
                     yvals = yvals * 1000
                 axs[ct].plot(
                     xvals,
@@ -121,7 +88,3 @@ for metric in metrics:
     fig.suptitle(f"{metric.value}")
     plt.tight_layout()
     fig.savefig(figure_path / f"all_simulators_{metric.value}_vs_time_subsampled.png")
-
-# %%
-
-# %%

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -15,6 +15,7 @@ plt.rcdefaults()
 metrics = [
     COMPRESSIONMETRIC.NON_COPLANARITY,
     COMPRESSIONMETRIC.PEAK_ASYMMETRY,
+    COMPRESSIONMETRIC.AVERAGE_PERP_DISTANCE,
     COMPRESSIONMETRIC.TOTAL_FIBER_TWIST,
     COMPRESSIONMETRIC.CALC_BENDING_ENERGY,
     COMPRESSIONMETRIC.CONTOUR_LENGTH,
@@ -66,7 +67,7 @@ for metric in metrics:
                     label = "_nolegend_"
                 xvals = np.linspace(0, 1, df_repeat["time"].nunique())
                 yvals = df_repeat.groupby("time")[metric.value].mean()
-                if simulator == "cytosim" and metric.value == "CONTOUR_LENGTH":
+                if simulator == "cytosim" and metric.value in ["CONTOUR_LENGTH", "AVERAGE_PERP_DISTANCE"]:
                     yvals = yvals * 1000
                 axs[ct].plot(
                     xvals,

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -17,6 +17,7 @@ metrics = [
     COMPRESSIONMETRIC.PEAK_ASYMMETRY,
     COMPRESSIONMETRIC.TOTAL_FIBER_TWIST,
     COMPRESSIONMETRIC.CALC_BENDING_ENERGY,
+    COMPRESSIONMETRIC.SPLINE_DISTANCE,
 ]
 
 # %% Process cytosim data
@@ -63,10 +64,14 @@ for metric in metrics:
                     label = f"{simulator}"
                 else:
                     label = "_nolegend_"
+                xvals = np.linspace(0, 1, df_repeat["time"].nunique())
+                yvals = df_repeat.groupby("time")[metric.value].mean()
+                if simulator == "cytosim" and metric.value == "SPLINE_DISTANCE":
+                    yvals = yvals * 1000
                 axs[ct].plot(
-                    np.linspace(0, 1, df_repeat["time"].nunique()),
+                    xvals,
                     # df_repeat["time"] * time_scale,
-                    df_repeat.groupby("time")[metric.value].mean(),
+                    yvals,
                     label=label,
                     color=color_map[simulator],
                     alpha=0.7,

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -67,7 +67,10 @@ for metric in metrics:
                     label = "_nolegend_"
                 xvals = np.linspace(0, 1, df_repeat["time"].nunique())
                 yvals = df_repeat.groupby("time")[metric.value].mean()
-                if simulator == "cytosim" and metric.value in ["CONTOUR_LENGTH", "AVERAGE_PERP_DISTANCE"]:
+                if simulator == "cytosim" and metric.value in [
+                    "CONTOUR_LENGTH",
+                    "AVERAGE_PERP_DISTANCE",
+                ]:
                     yvals = yvals * 1000
                 axs[ct].plot(
                     xvals,

--- a/notebooks/compare_metric_plots.py
+++ b/notebooks/compare_metric_plots.py
@@ -54,6 +54,7 @@ color_map = {"cytosim": "C0", "readdy": "C1"}
 
 # %% plot metrics vs time
 num_velocities = df["velocity"].nunique()
+compression_distance = 0.3  # um
 for metric in metrics:
     fig, axs = plt.subplots(
         1, num_velocities, figsize=(num_velocities * 5, 5), sharey=True, dpi=300
@@ -65,7 +66,8 @@ for metric in metrics:
                     label = f"{simulator}"
                 else:
                     label = "_nolegend_"
-                xvals = np.linspace(0, 1, df_repeat["time"].nunique())
+                total_time = compression_distance / velocity  # s
+                xvals = np.linspace(0, 1, df_repeat["time"].nunique()) * total_time
                 yvals = df_repeat.groupby("time")[metric.value].mean()
                 if simulator == "cytosim" and metric.value in [
                     "CONTOUR_LENGTH",
@@ -80,11 +82,12 @@ for metric in metrics:
                     color=color_map[simulator],
                     alpha=0.7,
                 )
+                plt.setp(axs[ct].get_xticklabels(), rotation=30, horizontalalignment='right')
         axs[ct].legend()
         axs[ct].set_title(f"Velocity: {velocity}")
         if ct == 0:
             axs[ct].set_ylabel(metric.value)
-    fig.supxlabel("Normalized time")
+    fig.supxlabel(R"Time ($\mu$s)")
     fig.suptitle(f"{metric.value}")
     plt.tight_layout()
     fig.savefig(figure_path / f"all_simulators_{metric.value}_vs_time_subsampled.png")

--- a/notebooks/sub_sample_simulations.py
+++ b/notebooks/sub_sample_simulations.py
@@ -54,10 +54,12 @@ for index, (simulator, df) in enumerate(
             for time, df_time in df_repeat.groupby("time"):
                 if time not in use_time_vals:
                     continue
+                normalized_time = df_time["normalized_time"].iloc[0]
                 print(f"velocity: {velocity}, repeat: {repeat}, time: {time}")
                 df_tmp = pd.DataFrame()
                 df_tmp["monomer_ids"] = np.arange(n_monomer_points)
                 df_tmp["time"] = time
+                df_tmp["normalized_time"] = normalized_time
                 df_tmp["velocity"] = velocity
                 df_tmp["repeat"] = repeat
                 df_tmp["simulator"] = simulator

--- a/notebooks/sub_sample_simulations.py
+++ b/notebooks/sub_sample_simulations.py
@@ -60,7 +60,7 @@ for index, df in enumerate(dfs):
                 df_subsample_list[index].append(df_tmp)
 
     df_subsampled[index] = pd.concat(df_subsample_list[index])
-    # %%
+# %%
 df_subsampled[0].to_csv(
     df_folder / "cytosim_actin_compression_subsampled.csv", index=False
 )

--- a/notebooks/sub_sample_simulations.py
+++ b/notebooks/sub_sample_simulations.py
@@ -11,11 +11,11 @@ df_folder = base_data_folder / "dataframes"
 df_folder.mkdir(parents=True, exist_ok=True)
 print(df_folder)
 # %%
-cytosim_df = pd.read_csv(
-    df_folder / "cytosim/cytosim_actin_compression_all_velocities_and_repeats.csv"
+cytosim_df = pd.read_parquet(
+    df_folder / "cytosim/cytosim_actin_compression_all_velocities_and_repeats.parquet"
 )
-readdy_df = pd.read_csv(
-    df_folder / "readdy/readdy_actin_compression_all_velocities_and_repeats.csv"
+readdy_df = pd.read_parquet(
+    df_folder / "readdy/readdy_actin_compression_all_velocities_and_repeats.parquet"
 )
 print(cytosim_df.shape)
 print(readdy_df.shape)
@@ -33,7 +33,12 @@ dfs = [cytosim_df, readdy_df]
 df_subsample_list = [[], []]
 df_subsampled = [[], []]
 # %%
-for index, df in enumerate(dfs):
+for index, (simulator, df) in enumerate(
+    zip(
+        ["cytosim", "readdy"],
+        dfs,
+    )
+):
     for velocity, df_velocity in df.groupby("velocity"):
         for repeat, df_repeat in df_velocity.groupby("repeat"):
             num_time_vals = df_repeat["time"].nunique()
@@ -55,6 +60,7 @@ for index, df in enumerate(dfs):
                 df_tmp["time"] = time
                 df_tmp["velocity"] = velocity
                 df_tmp["repeat"] = repeat
+                df_tmp["simulator"] = simulator
                 for col in cols_to_interp:
                     df_tmp[col] = np.interp(
                         np.linspace(0, 1, n_monomer_points),
@@ -70,6 +76,12 @@ df_subsampled[0].to_csv(
 )
 df_subsampled[1].to_csv(
     df_folder / "readdy/readdy_actin_compression_subsampled.csv", index=False
+)
+df_subsampled[0].to_parquet(
+    df_folder / "cytosim/cytosim_actin_compression_subsampled.parquet", index=False
+)
+df_subsampled[1].to_parquet(
+    df_folder / "readdy/readdy_actin_compression_subsampled.parquet", index=False
 )
 # %% get df for given velocity and repeat
 cytosim_subsampled = df_subsampled[0]

--- a/notebooks/sub_sample_simulations.py
+++ b/notebooks/sub_sample_simulations.py
@@ -5,13 +5,17 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 
 # %% load dataframes
-df_folder = Path("../data/dataframes")
+current_folder = Path(__file__).parent
+base_data_folder = current_folder.parent / "data"
+df_folder = base_data_folder / "dataframes"
+df_folder.mkdir(parents=True, exist_ok=True)
+print(df_folder)
 # %%
 cytosim_df = pd.read_csv(
-    df_folder / "cytosim_actin_compression_all_velocities_and_repeats.csv"
+    df_folder / "cytosim/cytosim_actin_compression_all_velocities_and_repeats.csv"
 )
 readdy_df = pd.read_csv(
-    df_folder / "readdy_actin_compression_all_velocities_and_repeats.csv"
+    df_folder / "readdy/readdy_actin_compression_all_velocities_and_repeats.csv"
 )
 print(cytosim_df.shape)
 print(readdy_df.shape)
@@ -62,10 +66,10 @@ for index, df in enumerate(dfs):
     df_subsampled[index] = pd.concat(df_subsample_list[index])
 # %%
 df_subsampled[0].to_csv(
-    df_folder / "cytosim_actin_compression_subsampled.csv", index=False
+    df_folder / "cytosim/cytosim_actin_compression_subsampled.csv", index=False
 )
 df_subsampled[1].to_csv(
-    df_folder / "readdy_actin_compression_subsampled.csv", index=False
+    df_folder / "readdy/readdy_actin_compression_subsampled.csv", index=False
 )
 # %% get df for given velocity and repeat
 cytosim_subsampled = df_subsampled[0]

--- a/notebooks/sub_sample_simulations.py
+++ b/notebooks/sub_sample_simulations.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 import matplotlib.pyplot as plt
+
 # %% load dataframes
 df_folder = Path("../data/dataframes")
 # %%
@@ -24,56 +25,59 @@ cols_to_interp = ["xpos", "ypos", "zpos"]
 # Here we will loop over df for readdy and cytosim, so that you can run the script from start to end
 # and it will subsample both the cytosim and readdy data
 
-
-df = readdy_df
-df_subsample_list = []
+dfs = [cytosim_df, readdy_df]
+df_subsample_list = [[], []]
+df_subsampled = [[], []]
 # %%
-for velocity, df_velocity in df.groupby("velocity"):
-    for repeat, df_repeat in df_velocity.groupby("repeat"):
-        num_time_vals = df_repeat["time"].nunique()
-        df_time_vals = df_repeat["time"].unique()
-        time_inds = np.rint(
-            np.interp(
-                np.linspace(0, 1, n_timepoints),
-                np.linspace(0, 1, num_time_vals),
-                np.arange(num_time_vals),
-            )
-        )
-        use_time_vals = df_time_vals[time_inds.astype(int)]
-        for time, df_time in df_repeat.groupby("time"):
-            if time not in use_time_vals:
-                continue
-            print(
-                f"velocity: {velocity}, repeat: {repeat}, time: {time}"
-            )
-            df_tmp = pd.DataFrame()
-            df_tmp["monomer_ids"] = np.arange(n_monomer_points)
-            df_tmp["time"] = time
-            df_tmp["velocity"] = velocity
-            df_tmp["repeat"] = repeat
-            for col in cols_to_interp:
-                df_tmp[col] = np.interp(
-                    np.linspace(0, 1, n_monomer_points),
-                    np.linspace(0, 1, df_time.shape[0]),
-                    df_time[col].values,
+for index, df in enumerate(dfs):
+    for velocity, df_velocity in df.groupby("velocity"):
+        for repeat, df_repeat in df_velocity.groupby("repeat"):
+            num_time_vals = df_repeat["time"].nunique()
+            df_time_vals = df_repeat["time"].unique()
+            time_inds = np.rint(
+                np.interp(
+                    np.linspace(0, 1, n_timepoints),
+                    np.linspace(0, 1, num_time_vals),
+                    np.arange(num_time_vals),
                 )
-            df_subsample_list.append(df_tmp)
+            )
+            use_time_vals = df_time_vals[time_inds.astype(int)]
+            for time, df_time in df_repeat.groupby("time"):
+                if time not in use_time_vals:
+                    continue
+                print(f"velocity: {velocity}, repeat: {repeat}, time: {time}")
+                df_tmp = pd.DataFrame()
+                df_tmp["monomer_ids"] = np.arange(n_monomer_points)
+                df_tmp["time"] = time
+                df_tmp["velocity"] = velocity
+                df_tmp["repeat"] = repeat
+                for col in cols_to_interp:
+                    df_tmp[col] = np.interp(
+                        np.linspace(0, 1, n_monomer_points),
+                        np.linspace(0, 1, df_time.shape[0]),
+                        df_time[col].values,
+                    )
+                df_subsample_list[index].append(df_tmp)
 
-df_subsampled = pd.concat(df_subsample_list)
-# %% 
-df_subsampled.to_csv(df_folder / "readdy_actin_compression_subsampled.csv", index=False)
-# %% get df for given velocity and repeat
-velocity_vals = df_subsampled["velocity"].unique()
-repeat_vals = df_subsampled["repeat"].unique()
-print(
-    f"velocity_vals: {velocity_vals}, repeat_vals: {repeat_vals}"
+    df_subsampled[index] = pd.concat(df_subsample_list[index])
+    # %%
+df_subsampled[0].to_csv(
+    df_folder / "cytosim_actin_compression_subsampled.csv", index=False
 )
+df_subsampled[1].to_csv(
+    df_folder / "readdy_actin_compression_subsampled.csv", index=False
+)
+# %% get df for given velocity and repeat
+cytosim_subsampled = df_subsampled[0]
+velocity_vals = cytosim_subsampled["velocity"].unique()
+repeat_vals = cytosim_subsampled["repeat"].unique()
+print(f"velocity_vals: {velocity_vals}, repeat_vals: {repeat_vals}")
 # %%
 velocity_ind = 0
 repeat_ind = 0
-df_test = df_subsampled[
-    (df_subsampled["velocity"] == velocity_vals[velocity_ind])
-    & (df_subsampled["repeat"] == repeat_vals[repeat_ind])
+df_test = cytosim_subsampled[
+    (cytosim_subsampled["velocity"] == velocity_vals[velocity_ind])
+    & (cytosim_subsampled["repeat"] == repeat_vals[repeat_ind])
 ]
 
 # %%
@@ -83,3 +87,4 @@ axs[1].plot(df_time["xpos"], df_time["ypos"], "ko-", ms=3, label="original")
 # axs[1].set_xlim([-0.1,-0.05 ])
 # ax.legend()
 plt.show()
+# %%

--- a/notebooks/sub_sample_simulations.py
+++ b/notebooks/sub_sample_simulations.py
@@ -1,0 +1,85 @@
+# %% imports
+import numpy as np
+import pandas as pd
+from pathlib import Path
+import matplotlib.pyplot as plt
+# %% load dataframes
+df_folder = Path("../data/dataframes")
+# %%
+cytosim_df = pd.read_csv(
+    df_folder / "cytosim_actin_compression_all_velocities_and_repeats.csv"
+)
+readdy_df = pd.read_csv(
+    df_folder / "readdy_actin_compression_all_velocities_and_repeats.csv"
+)
+print(cytosim_df.shape)
+print(readdy_df.shape)
+
+# %%
+n_timepoints = 200
+n_monomer_points = 200
+# %%
+cols_to_interp = ["xpos", "ypos", "zpos"]
+# %%
+# Here we will loop over df for readdy and cytosim, so that you can run the script from start to end
+# and it will subsample both the cytosim and readdy data
+
+
+df = readdy_df
+df_subsample_list = []
+# %%
+for velocity, df_velocity in df.groupby("velocity"):
+    for repeat, df_repeat in df_velocity.groupby("repeat"):
+        num_time_vals = df_repeat["time"].nunique()
+        df_time_vals = df_repeat["time"].unique()
+        time_inds = np.rint(
+            np.interp(
+                np.linspace(0, 1, n_timepoints),
+                np.linspace(0, 1, num_time_vals),
+                np.arange(num_time_vals),
+            )
+        )
+        use_time_vals = df_time_vals[time_inds.astype(int)]
+        for time, df_time in df_repeat.groupby("time"):
+            if time not in use_time_vals:
+                continue
+            print(
+                f"velocity: {velocity}, repeat: {repeat}, time: {time}"
+            )
+            df_tmp = pd.DataFrame()
+            df_tmp["monomer_ids"] = np.arange(n_monomer_points)
+            df_tmp["time"] = time
+            df_tmp["velocity"] = velocity
+            df_tmp["repeat"] = repeat
+            for col in cols_to_interp:
+                df_tmp[col] = np.interp(
+                    np.linspace(0, 1, n_monomer_points),
+                    np.linspace(0, 1, df_time.shape[0]),
+                    df_time[col].values,
+                )
+            df_subsample_list.append(df_tmp)
+
+df_subsampled = pd.concat(df_subsample_list)
+# %% 
+df_subsampled.to_csv(df_folder / "readdy_actin_compression_subsampled.csv", index=False)
+# %% get df for given velocity and repeat
+velocity_vals = df_subsampled["velocity"].unique()
+repeat_vals = df_subsampled["repeat"].unique()
+print(
+    f"velocity_vals: {velocity_vals}, repeat_vals: {repeat_vals}"
+)
+# %%
+velocity_ind = 0
+repeat_ind = 0
+df_test = df_subsampled[
+    (df_subsampled["velocity"] == velocity_vals[velocity_ind])
+    & (df_subsampled["repeat"] == repeat_vals[repeat_ind])
+]
+
+# %%
+fig, axs = plt.subplots(2, 1, sharex=True)
+axs[0].plot(df_tmp["xpos"], df_tmp["ypos"], "ro-", ms=3, label="subsampled")
+axs[1].plot(df_time["xpos"], df_time["ypos"], "ko-", ms=3, label="original")
+# axs[1].set_xlim([-0.1,-0.05 ])
+# ax.legend()
+plt.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "container-collection",
   "boto3",
   "scikit-learn",
+  "s3fs",
   "pyarrow",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
   "simulariumio",
   "container-collection",
   "boto3",
-  "scikit-learn"
+  "scikit-learn",
+  "pyarrow",
 ]
 
 [project.urls]

--- a/subcell_analysis/compression_analysis.py
+++ b/subcell_analysis/compression_analysis.py
@@ -19,7 +19,7 @@ class COMPRESSIONMETRIC(Enum):
     TOTAL_FIBER_TWIST = "TOTAL_FIBER_TWIST"
     ENERGY_ASYMMETRY = "ENERGY_ASYMMETRY"
     CALC_BENDING_ENERGY = "CALC_BENDING_ENERGY"
-    SPLINE_DISTANCE = "SPLINE_DISTANCE"
+    CONTOUR_LENGTH = "CONTOUR_LENGTH"
 
 
 def get_end_to_end_unit_vector(
@@ -188,7 +188,7 @@ def get_pca_polymer_trace_projection(
     return pca.transform(polymer_trace)
 
 
-def get_spline_distance_from_trace(
+def get_contour_length_from_trace(
     polymer_trace: np.ndarray,
     **options: dict,
 ) -> float:

--- a/subcell_analysis/compression_analysis.py
+++ b/subcell_analysis/compression_analysis.py
@@ -19,6 +19,7 @@ class COMPRESSIONMETRIC(Enum):
     TOTAL_FIBER_TWIST = "TOTAL_FIBER_TWIST"
     ENERGY_ASYMMETRY = "ENERGY_ASYMMETRY"
     CALC_BENDING_ENERGY = "CALC_BENDING_ENERGY"
+    SPLINE_DISTANCE = "SPLINE_DISTANCE"
 
 
 def get_end_to_end_unit_vector(
@@ -185,6 +186,31 @@ def get_pca_polymer_trace_projection(
     """
     pca = fit_pca_to_polymer_trace(polymer_trace=polymer_trace)
     return pca.transform(polymer_trace)
+
+
+def get_spline_distance_from_trace(
+    polymer_trace: np.ndarray,
+    **options: dict,
+) -> float:
+    """
+    Returns the sum of inter-monomer distances in the trace
+
+    Parameters
+    ----------
+    polymer_trace: [n x 3] numpy array
+        array containing the x,y,z positions of the polymer trace
+    **options: dict
+        Additional options as key-value pairs.
+
+    Returns
+    ----------
+    total_distance: float
+        sum of inter-monomer distances in the trace
+    """
+    total_distance = 0
+    for i in range(len(polymer_trace) - 1):
+        total_distance += np.linalg.norm(polymer_trace[i] - polymer_trace[i + 1])
+    return total_distance
 
 
 def get_bending_energy_from_trace(

--- a/subcell_analysis/compression_analysis.py
+++ b/subcell_analysis/compression_analysis.py
@@ -193,7 +193,7 @@ def get_contour_length_from_trace(
     **options: dict,
 ) -> float:
     """
-    Returns the sum of inter-monomer distances in the trace
+    Returns the sum of inter-monomer distances in the trace.
 
     Parameters
     ----------
@@ -203,7 +203,7 @@ def get_contour_length_from_trace(
         Additional options as key-value pairs.
 
     Returns
-    ----------
+    -------
     total_distance: float
         sum of inter-monomer distances in the trace
     """
@@ -281,7 +281,9 @@ def get_total_fiber_twist(
     ]
     trace_2d = trace_2d - np.mean(trace_2d, axis=0)
 
-    return get_total_fiber_twist_2d(trace_2d, signed=signed, tolerance=tolerance)
+    return get_total_fiber_twist_2d(
+        trace_2d, signed=signed, tolerance=tolerance  # type: ignore
+    )
 
 
 def get_total_fiber_twist_pca(

--- a/subcell_analysis/compression_workflow_runner.py
+++ b/subcell_analysis/compression_workflow_runner.py
@@ -11,7 +11,7 @@ from .compression_analysis import (
     get_third_component_variance,
     get_total_fiber_twist,
     get_bending_energy_from_trace,
-    get_spline_distance_from_trace,
+    get_contour_length_from_trace,
 )
 
 ABS_TOL = 1e-6
@@ -81,11 +81,11 @@ def run_metric_calculation(
                 **options,
             )
 
-        if metric == COMPRESSIONMETRIC.SPLINE_DISTANCE:
+        if metric == COMPRESSIONMETRIC.CONTOUR_LENGTH:
             polymer_trace = fiber_at_time[["xpos", "ypos", "zpos"]].values
             all_points.loc[
                 fiber_at_time.index, metric.value
-            ] = get_spline_distance_from_trace(polymer_trace, **options)
+            ] = get_contour_length_from_trace(polymer_trace, **options)
 
         if metric == COMPRESSIONMETRIC.SUM_BENDING_ENERGY:
             polymer_trace = fiber_at_time[

--- a/subcell_analysis/compression_workflow_runner.py
+++ b/subcell_analysis/compression_workflow_runner.py
@@ -6,12 +6,12 @@ from .compression_analysis import (
     COMPRESSIONMETRIC,
     get_asymmetry_of_peak,
     get_average_distance_from_end_to_end_axis,
+    get_bending_energy_from_trace,
+    get_contour_length_from_trace,
     get_energy_asymmetry,
     get_sum_bending_energy,
     get_third_component_variance,
     get_total_fiber_twist,
-    get_bending_energy_from_trace,
-    get_contour_length_from_trace,
 )
 
 ABS_TOL = 1e-6

--- a/subcell_analysis/compression_workflow_runner.py
+++ b/subcell_analysis/compression_workflow_runner.py
@@ -11,6 +11,7 @@ from .compression_analysis import (
     get_third_component_variance,
     get_total_fiber_twist,
     get_bending_energy_from_trace,
+    get_spline_distance_from_trace,
 )
 
 ABS_TOL = 1e-6
@@ -79,6 +80,12 @@ def run_metric_calculation(
                 polymer_trace,
                 **options,
             )
+
+        if metric == COMPRESSIONMETRIC.SPLINE_DISTANCE:
+            polymer_trace = fiber_at_time[["xpos", "ypos", "zpos"]].values
+            all_points.loc[
+                fiber_at_time.index, metric.value
+            ] = get_spline_distance_from_trace(polymer_trace, **options)
 
         if metric == COMPRESSIONMETRIC.SUM_BENDING_ENERGY:
             polymer_trace = fiber_at_time[

--- a/subcell_analysis/compression_workflow_runner.py
+++ b/subcell_analysis/compression_workflow_runner.py
@@ -10,6 +10,7 @@ from .compression_analysis import (
     get_sum_bending_energy,
     get_third_component_variance,
     get_total_fiber_twist,
+    get_bending_energy_from_trace,
 )
 
 ABS_TOL = 1e-6
@@ -67,9 +68,6 @@ def run_metric_calculation(
             polymer_trace = fiber_at_time[["xpos", "ypos", "zpos"]].values
             all_points.loc[fiber_at_time.index, metric.value] = get_total_fiber_twist(
                 polymer_trace,
-                compression_axis=0,
-                signed=True,
-                tolerance=ABS_TOL,
                 **options,
             )
 
@@ -89,6 +87,13 @@ def run_metric_calculation(
             all_points.loc[fiber_at_time.index, metric.value] = get_sum_bending_energy(
                 polymer_trace, **options
             )
+
+        if metric == COMPRESSIONMETRIC.CALC_BENDING_ENERGY:
+            polymer_trace = fiber_at_time[["xpos", "ypos", "zpos"]].values
+            all_points.loc[
+                fiber_at_time.index, metric.value
+            ] = get_bending_energy_from_trace(polymer_trace, **options)
+
     return all_points
 
 

--- a/subcell_analysis/cytosim/post_process_cytosim.py
+++ b/subcell_analysis/cytosim/post_process_cytosim.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 import boto3
 import numpy as np
@@ -122,7 +122,8 @@ def get_s3_file(bucket_name: str, file_name: str) -> object:
         bucket_name (str): The name of the S3 bucket.
         file_name (str): The name of the file to retrieve.
 
-    Returns:
+    Returns
+    -------
         object: The contents of the file as a byte string.
     """
     s3 = boto3.client("s3")
@@ -136,20 +137,33 @@ def create_dataframes_for_repeats(
     configs: list,
     save_folder: Path,
     file_name: str = "cytosim_actin_compression",
-    velocities: list = None,
+    velocities: Optional[list] = None,
     overwrite: bool = True,
 ) -> None:
     """
-    Create dataframes for all repeats of given configs.
+    Create dataframes for repeated simulations in Cytosim.
 
-    Args:
-        bucket_name (str): The name of the bucket.
-        num_repeats (int): The number of repeats.
-        configs (list): A list of configurations.
-        save_folder (Path): The path to the folder where the dataframes will be saved.
-        file_name (str, optional): The name of the file. Defaults to "cytosim_actin_compression".
-        velocities (list, optional): A list of velocities. Defaults to None.
-        overwrite (bool, optional): Whether to overwrite existing dataframes. Defaults to True.
+    Parameters
+    ----------
+    bucket_name : str
+        The name of the bucket.
+    num_repeats : int
+        The number of repeats.
+    configs : list
+        The list of configurations.
+    save_folder : Path
+        The path to the save folder.
+    file_name : str, optional
+        The name of the file. Defaults to "cytosim_actin_compression".
+    velocities : list, optional
+        The list of velocities. Defaults to None.
+    overwrite : bool, optional
+        Whether to overwrite existing files. Defaults to True.
+
+    Returns
+    -------
+    None
+        This function does not return anything.
     """
     segenergy = np.empty((len(configs), num_repeats), dtype=object)
     fibenergy = np.empty((len(configs), num_repeats), dtype=object)

--- a/subcell_analysis/postprocessing/create_combined_dataframe.py
+++ b/subcell_analysis/postprocessing/create_combined_dataframe.py
@@ -1,12 +1,16 @@
 # %% [markdown]
 # # Create combined dataframe
-# 1. Run create_dataframes_from_cytosim_outputs.py to create dataframes for all repeats of given configs for cytosim.
-# 2. Run create_dataframes_from_readdy_outputs.py to create dataframes for all repeats of given configs for readdy.
-# 3. Run create_combined_dataframe.py to combine the dataframes from cytosim and readdy.
+# 1. Run create_dataframes_from_cytosim_outputs.py
+# to create dataframes for all repeats of given configs for cytosim.
+# 2. Run create_dataframes_from_readdy_outputs.py
+# to create dataframes for all repeats of given configs for readdy.
+# 3. Run create_combined_dataframe.py
+# to combine the dataframes from cytosim and readdy.
 
 # %%
-import pandas as pd
 from pathlib import Path
+
+import pandas as pd
 
 # %% [markdown]
 # ## setup output folders
@@ -17,14 +21,22 @@ readdy_df_path = base_df_path / "readdy"
 print(base_df_path)
 
 # %%
-cytosim_df = pd.read_csv(cytosim_df_path / "cytosim_actin_compression_all_velocities_and_repeats.csv")
-readdy_df = pd.read_csv(readdy_df_path / "readdy_actin_compression_all_velocities_and_repeats.csv")
+cytosim_df = pd.read_csv(
+    cytosim_df_path / "cytosim_actin_compression_all_velocities_and_repeats.csv"
+)
+readdy_df = pd.read_csv(
+    readdy_df_path / "readdy_actin_compression_all_velocities_and_repeats.csv"
+)
 # %% convert columns to compressible types
 cytosim_df = cytosim_df.convert_dtypes()
 readdy_df = readdy_df.convert_dtypes()
 # %% save df as parquet
-cytosim_df.to_parquet(cytosim_df_path / "cytosim_actin_compression_all_velocities_and_repeats.parquet")
-readdy_df.to_parquet(readdy_df_path / "readdy_actin_compression_all_velocities_and_repeats.parquet")
+cytosim_df.to_parquet(
+    cytosim_df_path / "cytosim_actin_compression_all_velocities_and_repeats.parquet"
+)
+readdy_df.to_parquet(
+    readdy_df_path / "readdy_actin_compression_all_velocities_and_repeats.parquet"
+)
 # %% merge dataframes
 combined_df = pd.concat([cytosim_df, readdy_df], ignore_index=True)
 unnamed_cols = [col for col in combined_df.columns if "Unnamed" in col]
@@ -32,31 +44,43 @@ combined_df = combined_df.drop(columns=unnamed_cols)
 combined_df = combined_df.drop(columns=["id"])
 combined_df = combined_df.convert_dtypes()
 # %% save as csv and parquet
-combined_df.to_csv(base_df_path / "combined_actin_compression_dataset_all_velocities_and_repeats.csv")
-combined_df.to_parquet(base_df_path / "combined_actin_compression_dataset_all_velocities_and_repeats.parquet")
+combined_df.to_csv(
+    base_df_path / "combined_actin_compression_dataset_all_velocities_and_repeats.csv"
+)
+combined_df.to_parquet(
+    base_df_path
+    / "combined_actin_compression_dataset_all_velocities_and_repeats.parquet"
+)
 # %% load subsampled dataframes
-subsampled_cytosim_df = pd.read_csv(cytosim_df_path / "cytosim_actin_compression_subsampled.csv")
-subsampled_readdy_df = pd.read_csv(readdy_df_path / "readdy_actin_compression_subsampled.csv")
+subsampled_cytosim_df = pd.read_csv(
+    cytosim_df_path / "cytosim_actin_compression_subsampled.csv"
+)
+subsampled_readdy_df = pd.read_csv(
+    readdy_df_path / "readdy_actin_compression_subsampled.csv"
+)
 # %% convert columns to compressible types
 subsampled_cytosim_df = subsampled_cytosim_df.convert_dtypes()
 subsampled_readdy_df = subsampled_readdy_df.convert_dtypes()
 # %% save df as parquet
-subsampled_cytosim_df.to_parquet(cytosim_df_path / "cytosim_actin_compression_subsampled.parquet")
-subsampled_readdy_df.to_parquet(readdy_df_path / "readdy_actin_compression_subsampled.parquet")
+subsampled_cytosim_df.to_parquet(
+    cytosim_df_path / "cytosim_actin_compression_subsampled.parquet"
+)
+subsampled_readdy_df.to_parquet(
+    readdy_df_path / "readdy_actin_compression_subsampled.parquet"
+)
 # %% combine subsampled dataframes
-subsampled_combined_df = pd.concat([subsampled_cytosim_df, subsampled_readdy_df], ignore_index=True)
+subsampled_combined_df = pd.concat(
+    [subsampled_cytosim_df, subsampled_readdy_df], ignore_index=True
+)
 unnamed_cols = [col for col in subsampled_combined_df.columns if "Unnamed" in col]
 subsampled_combined_df = subsampled_combined_df.drop(columns=unnamed_cols)
 subsampled_combined_df = subsampled_combined_df.convert_dtypes()
 # %% save as csv and parquet
-subsampled_combined_df.to_csv(base_df_path / "combined_actin_compression_dataset_all_velocities_and_repeats_subsampled.csv")
-subsampled_combined_df.to_parquet(base_df_path / "combined_actin_compression_dataset_all_velocities_and_repeats_subsampled.parquet")
-
-# %% check loading times
-%%time
-df_all_csv = pd.read_csv("s3://readdy-working-bucket/dataframes/combined_actin_compression_dataset_all_velocities_and_repeats.csv")
-# %%
-%%time
-df_all_parquet = pd.read_parquet("s3://readdy-working-bucket/dataframes/combined_actin_compression_dataset_all_velocities_and_repeats.parquet")
-
-# %%
+subsampled_combined_df.to_csv(
+    base_df_path
+    / "combined_actin_compression_dataset_all_velocities_and_repeats_subsampled.csv"
+)
+subsampled_combined_df.to_parquet(
+    base_df_path
+    / "combined_actin_compression_dataset_all_velocities_and_repeats_subsampled.parquet"
+)

--- a/subcell_analysis/postprocessing/create_combined_dataframe.py
+++ b/subcell_analysis/postprocessing/create_combined_dataframe.py
@@ -42,9 +42,12 @@ cytosim_compression_velocities = [0.15, 0.47434165, 1.5, 4.7, 15, 47, 150]
 
 # %% [markdown]
 # ## Combine all cytosim outputs
+
+# TODO: this snippet is repeated. Could be moved to a function?
 num_repeats = 5
 velocity_inds = range(3, 7)
 df_list = []
+simulator = "cytosim"
 for index in velocity_inds:
     for repeat in range(num_repeats):
         print(
@@ -57,6 +60,7 @@ for index in velocity_inds:
 
         df_tmp["velocity"] = cytosim_compression_velocities[index]
         df_tmp["repeat"] = repeat
+        df_tmp["simulator"] = simulator
         df_list.append(df_tmp)
 df_cytosim = pd.concat(df_list)
 df_cytosim.to_csv(
@@ -67,6 +71,7 @@ df_cytosim.to_csv(
 # ## Combine all readdy outputs
 num_repeats = 3
 df_list = []
+simulator = "readdy"
 for velocity in readdy_compression_velocities:
     for repeat in range(num_repeats):
         file_path = (
@@ -80,6 +85,7 @@ for velocity in readdy_compression_velocities:
         print(f"Calculating velocity {velocity} and repeat {repeat}")
         df_tmp["velocity"] = velocity
         df_tmp["repeat"] = repeat
+        df_tmp["simulator"] = simulator
         df_list.append(df_tmp)
 
 df_readdy = pd.concat(df_list)
@@ -89,8 +95,6 @@ df_readdy.to_csv(
 
 # %% [markdown]
 # ## Combine readdy output with cytosim
-df_cytosim["simulator"] = "cytosim"
-df_readdy["simulator"] = "readdy"
 df_combined = pd.concat([df_cytosim, df_readdy])
 
 # %% [markdown]

--- a/subcell_analysis/postprocessing/create_combined_dataframe.py
+++ b/subcell_analysis/postprocessing/create_combined_dataframe.py
@@ -1,0 +1,103 @@
+# %%
+import pandas as pd
+from pathlib import Path
+
+from subcell_analysis.cytosim.post_process_cytosim import create_dataframes_for_repeats
+
+# %% [markdown]
+# ## setup output folders
+current_folder = Path(__file__).parent
+base_df_path = current_folder.parents[1] / "data/dataframes"
+cytosim_df_path = base_df_path / "cytosim"
+readdy_df_path = base_df_path / "readdy"
+print(base_df_path)
+# %% [markdown]
+# # Process individual cytosim outputs to csv files
+# %% [markdown]
+# ## setup parameters for accessing data from s3
+bucket_name = "cytosim-working-bucket"
+num_repeats = 5
+num_velocities = 7
+configs = [f"vary_compress_rate000{num}" for num in range(3, num_velocities)]
+# %% [markdown]
+# ## convert individual outputs to dataframes
+create_dataframes_for_repeats(
+    bucket_name=bucket_name,
+    num_repeats=num_repeats,
+    configs=configs,
+    save_folder=cytosim_df_path,
+    file_name="cytosim_actin_compression",
+    overwrite=False,
+)
+# %% [markdown]
+# # Process individual readdy outputs to csv files
+# %%
+## TODO: add code to process readdy outputs to csv files
+# %% [markdown]
+# # Start workflow to combine outputs
+# %% [markdown] 
+# ## set velocities
+readdy_compression_velocities = [4.7, 15, 47, 150]
+cytosim_compression_velocities = [0.15, 0.47434165, 1.5, 4.7, 15, 47, 150]
+
+# %% [markdown]
+# ## Combine all cytosim outputs
+num_repeats = 5
+velocity_inds = range(3, 7)
+df_list = []
+for index in velocity_inds:
+    for repeat in range(num_repeats):
+        print(
+            f"Calculating velocity {cytosim_compression_velocities[index]} and repeat {repeat}"
+        )
+        df_tmp = pd.read_csv(
+            cytosim_df_path
+            / f"cytosim_actin_compression_velocity_vary_compress_rate000{index}_repeat_{repeat}.csv"
+        )
+
+        df_tmp["velocity"] = cytosim_compression_velocities[index]
+        df_tmp["repeat"] = repeat
+        df_list.append(df_tmp)
+df_cytosim = pd.concat(df_list)
+df_cytosim.to_csv(
+    cytosim_df_path / "cytosim_actin_compression_all_velocities_and_repeats.csv"
+)
+
+# %% [markdown]
+# ## Combine all readdy outputs
+num_repeats = 3
+df_list = []
+for velocity in readdy_compression_velocities:
+    for repeat in range(num_repeats):
+        file_path = (
+            readdy_df_path
+            / f"readdy_actin_compression_velocity_{velocity}_repeat_{repeat}.csv"
+        )
+        if file_path.is_file():
+            df_tmp = pd.read_csv(file_path)
+        else:
+            continue
+        print(f"Calculating velocity {velocity} and repeat {repeat}")
+        df_tmp["velocity"] = velocity
+        df_tmp["repeat"] = repeat
+        df_list.append(df_tmp)
+
+df_readdy = pd.concat(df_list)
+df_readdy.to_csv(
+    readdy_df_path / "readdy_actin_compression_all_velocities_and_repeats.csv"
+)
+
+# %% [markdown]
+# ## Combine readdy output with cytosim
+df_cytosim["simulator"] = "cytosim"
+df_readdy["simulator"] = "readdy"
+df_combined = pd.concat([df_cytosim, df_readdy])
+
+# %% [markdown]
+# ### save combined df
+df_combined.to_csv(base_df_path / "combined_actin_compression_dataset.csv")
+df_combined.head()
+
+# %% [markdown]
+# # Create combined subsampled dataset
+# TODO: add code to create subsampled dataset

--- a/subcell_analysis/postprocessing/create_combined_dataframe.py
+++ b/subcell_analysis/postprocessing/create_combined_dataframe.py
@@ -21,20 +21,10 @@ readdy_df_path = base_df_path / "readdy"
 print(base_df_path)
 
 # %%
-cytosim_df = pd.read_csv(
-    cytosim_df_path / "cytosim_actin_compression_all_velocities_and_repeats.csv"
-)
-readdy_df = pd.read_csv(
-    readdy_df_path / "readdy_actin_compression_all_velocities_and_repeats.csv"
-)
-# %% convert columns to compressible types
-cytosim_df = cytosim_df.convert_dtypes()
-readdy_df = readdy_df.convert_dtypes()
-# %% save df as parquet
-cytosim_df.to_parquet(
+cytosim_df = pd.read_parquet(
     cytosim_df_path / "cytosim_actin_compression_all_velocities_and_repeats.parquet"
 )
-readdy_df.to_parquet(
+readdy_df = pd.read_parquet(
     readdy_df_path / "readdy_actin_compression_all_velocities_and_repeats.parquet"
 )
 # %% merge dataframes
@@ -42,7 +32,6 @@ combined_df = pd.concat([cytosim_df, readdy_df], ignore_index=True)
 unnamed_cols = [col for col in combined_df.columns if "Unnamed" in col]
 combined_df = combined_df.drop(columns=unnamed_cols)
 combined_df = combined_df.drop(columns=["id"])
-combined_df = combined_df.convert_dtypes()
 # %% save as csv and parquet
 combined_df.to_csv(
     base_df_path / "combined_actin_compression_dataset_all_velocities_and_repeats.csv"
@@ -52,20 +41,10 @@ combined_df.to_parquet(
     / "combined_actin_compression_dataset_all_velocities_and_repeats.parquet"
 )
 # %% load subsampled dataframes
-subsampled_cytosim_df = pd.read_csv(
-    cytosim_df_path / "cytosim_actin_compression_subsampled.csv"
-)
-subsampled_readdy_df = pd.read_csv(
-    readdy_df_path / "readdy_actin_compression_subsampled.csv"
-)
-# %% convert columns to compressible types
-subsampled_cytosim_df = subsampled_cytosim_df.convert_dtypes()
-subsampled_readdy_df = subsampled_readdy_df.convert_dtypes()
-# %% save df as parquet
-subsampled_cytosim_df.to_parquet(
+subsampled_cytosim_df = pd.read_parquet(
     cytosim_df_path / "cytosim_actin_compression_subsampled.parquet"
 )
-subsampled_readdy_df.to_parquet(
+subsampled_readdy_df = pd.read_parquet(
     readdy_df_path / "readdy_actin_compression_subsampled.parquet"
 )
 # %% combine subsampled dataframes
@@ -74,7 +53,6 @@ subsampled_combined_df = pd.concat(
 )
 unnamed_cols = [col for col in subsampled_combined_df.columns if "Unnamed" in col]
 subsampled_combined_df = subsampled_combined_df.drop(columns=unnamed_cols)
-subsampled_combined_df = subsampled_combined_df.convert_dtypes()
 # %% save as csv and parquet
 subsampled_combined_df.to_csv(
     base_df_path

--- a/subcell_analysis/postprocessing/create_combined_dataframe.py
+++ b/subcell_analysis/postprocessing/create_combined_dataframe.py
@@ -35,7 +35,7 @@ create_dataframes_for_repeats(
 ## TODO: add code to process readdy outputs to csv files
 # %% [markdown]
 # # Start workflow to combine outputs
-# %% [markdown] 
+# %% [markdown]
 # ## set velocities
 readdy_compression_velocities = [4.7, 15, 47, 150]
 cytosim_compression_velocities = [0.15, 0.47434165, 1.5, 4.7, 15, 47, 150]
@@ -50,18 +50,22 @@ df_list = []
 simulator = "cytosim"
 for index in velocity_inds:
     for repeat in range(num_repeats):
-        print(
-            f"Calculating velocity {cytosim_compression_velocities[index]} and repeat {repeat}"
-        )
-        df_tmp = pd.read_csv(
+        file_path = (
             cytosim_df_path
             / f"cytosim_actin_compression_velocity_vary_compress_rate000{index}_repeat_{repeat}.csv"
         )
-
+        if file_path.is_file():
+            df_tmp = pd.read_csv(file_path)
+        else:
+            continue
+        print(
+            f"Processing velocity {cytosim_compression_velocities[index]} and repeat {repeat}"
+        )
         df_tmp["velocity"] = cytosim_compression_velocities[index]
         df_tmp["repeat"] = repeat
         df_tmp["simulator"] = simulator
         df_list.append(df_tmp)
+
 df_cytosim = pd.concat(df_list)
 df_cytosim.to_csv(
     cytosim_df_path / "cytosim_actin_compression_all_velocities_and_repeats.csv"
@@ -82,7 +86,7 @@ for velocity in readdy_compression_velocities:
             df_tmp = pd.read_csv(file_path)
         else:
             continue
-        print(f"Calculating velocity {velocity} and repeat {repeat}")
+        print(f"Processing velocity {velocity} and repeat {repeat}")
         df_tmp["velocity"] = velocity
         df_tmp["repeat"] = repeat
         df_tmp["simulator"] = simulator

--- a/subcell_analysis/postprocessing/create_dataframes_from_cytosim_outputs.py
+++ b/subcell_analysis/postprocessing/create_dataframes_from_cytosim_outputs.py
@@ -1,0 +1,73 @@
+# %%
+import pandas as pd
+from pathlib import Path
+
+from subcell_analysis.cytosim.post_process_cytosim import create_dataframes_for_repeats
+
+# %% [markdown]
+# ### setup output folders
+current_folder = Path(__file__).parent
+base_df_path = current_folder.parents[1] / "data/dataframes"
+cytosim_df_path = base_df_path / "cytosim"
+print(cytosim_df_path)
+# %% [markdown]
+# # Process individual cytosim outputs to csv files
+# %% [markdown]
+# ## setup parameters for accessing data from s3
+bucket_name = "cytosim-working-bucket"
+num_repeats = 5
+velocity_inds = range(3, 7)
+all_cytosim_compression_velocities = [0.15, 0.47434165, 1.5, 4.7, 15, 47, 150]
+cytosim_compression_velocities = [
+    all_cytosim_compression_velocities[num] for num in velocity_inds
+]
+configs = [f"vary_compress_rate000{num}" for num in velocity_inds]
+# %% [markdown]
+# ## convert individual outputs to dataframes
+create_dataframes_for_repeats(
+    bucket_name=bucket_name,
+    num_repeats=num_repeats,
+    configs=configs,
+    save_folder=cytosim_df_path,
+    file_name="cytosim_actin_compression",
+    velocities=cytosim_compression_velocities,
+    overwrite=True,
+)
+# %% [markdown]
+# # Workflow to combine repeats and velocities
+# %% [markdown]
+# %% [markdown]
+# ## Combine all cytosim outputs
+num_repeats = 5
+df_list = []
+simulator = "cytosim"
+for velocity in cytosim_compression_velocities:
+    for repeat in range(num_repeats):
+        file_path = (
+            cytosim_df_path
+            / f"cytosim_actin_compression_velocity_{velocity}_repeat_{repeat}.csv"
+        )
+        if file_path.is_file():
+            print(f"Reading velocity {velocity} and repeat {repeat}")
+            df_tmp = pd.read_csv(file_path)
+        else:
+            print(f"Missing csv. Skipped velocity {velocity} and repeat {repeat}")
+            continue
+        df_tmp["velocity"] = velocity
+        df_tmp["repeat"] = repeat
+        df_tmp["simulator"] = simulator
+        time_vals = df_tmp["time"]
+        df_tmp["normalized_time"] = (time_vals - time_vals.min()) / (
+            time_vals.max() - time_vals.min()
+        )
+        df_list.append(df_tmp)
+# %%
+df_cytosim = pd.concat(df_list)
+df_cytosim.to_csv(
+    cytosim_df_path / "cytosim_actin_compression_all_velocities_and_repeats.csv"
+)
+df_cytosim.to_parquet(
+    cytosim_df_path / "cytosim_actin_compression_all_velocities_and_repeats.parquet"
+)
+
+# %%

--- a/subcell_analysis/postprocessing/create_dataframes_from_readdy_outputs.py
+++ b/subcell_analysis/postprocessing/create_dataframes_from_readdy_outputs.py
@@ -1,0 +1,148 @@
+# %% [markdown]
+# # Process individual readdy outputs to csv files
+# %% imports
+import boto3
+import numpy as np
+import pandas as pd
+from pathlib import Path
+
+from subcell_analysis.readdy import (
+    ReaddyLoader,
+    ReaddyPostProcessor,
+)
+from subcell_analysis.readdy.readdy_post_processor import array_to_dataframe
+
+# %% [markdown]
+# ### setup output folders
+current_folder = Path(__file__).parent
+base_data_path = current_folder.parents[1] / "data"
+readdy_df_path = base_data_path / "dataframes/readdy"
+readdy_df_path.mkdir(exist_ok=True, parents=True)
+print(readdy_df_path)
+# %% [markdown]
+# ## setup parameters to download h5 files from s3
+redownload = False
+h5_folder_path = base_data_path / "readdy_h5_files"
+h5_folder_path.mkdir(exist_ok=True, parents=True)
+print(h5_folder_path)
+bucket_name = "readdy-working-bucket"
+# %% [markdown]
+# ## setup velocities and repeats
+readdy_compression_velocities = [4.7, 15, 47, 150]
+num_repeats = 5
+
+# %% [markdown]
+# ## download h5 files from s3
+s3 = boto3.client("s3")
+for velocity in readdy_compression_velocities:
+    for repeat in range(num_repeats):
+        file_name = f"actin_compression_velocity={velocity}_{repeat}.h5"
+        h5_file_path = h5_folder_path / file_name
+        if h5_file_path.is_file() and not redownload:
+            print(f"{file_name} already exists")
+            continue
+        else:
+            print(f"Downloading {file_name}")
+            try:
+                response = s3.download_file(
+                    bucket_name,
+                    f"outputs/{file_name}",
+                    str(h5_file_path),
+                )
+            except Exception as e:
+                print(e)
+
+# %%
+reprocess = True
+df_list = []
+for v_index, velocity in enumerate(readdy_compression_velocities):
+    for repeat in range(num_repeats):
+        file_name = f"actin_compression_velocity={velocity}_{repeat}.h5"
+        df_save_path = (
+            readdy_df_path
+            / f"readdy_actin_compression_velocity_{velocity}_repeat_{repeat}.csv"
+        )
+
+        if df_save_path.is_file() and not reprocess:
+            print(f"{file_name} already processed")
+            df_points = pd.read_csv(df_save_path)
+            df_list.append(df_points)
+            continue
+
+        if v_index == 1 and repeat == 2:
+            print(f"Skipping {file_name} due to processing error")
+            continue
+
+        h5_file_path = h5_folder_path / file_name
+
+        if not h5_file_path.is_file():
+            print(f"{file_name} not found")
+            continue
+
+        print(f"Processing {file_name}")
+        readdy_loader = ReaddyLoader(str(h5_file_path))
+        readdy_post_processor = ReaddyPostProcessor(
+            readdy_loader.trajectory(),
+            box_size=600.0 * np.ones(3),
+        )
+        fiber_chain_ids = readdy_post_processor.linear_fiber_chain_ids(
+            start_particle_phrases=["pointed"],
+            other_particle_types=[
+                "actin#",
+                "actin#ATP_",
+                "actin#mid_",
+                "actin#mid_ATP_",
+                "actin#fixed_",
+                "actin#fixed_ATP_",
+                "actin#mid_fixed_",
+                "actin#mid_fixed_ATP_",
+                "actin#barbed_",
+                "actin#barbed_ATP_",
+                "actin#fixed_barbed_",
+                "actin#fixed_barbed_ATP_",
+            ],
+            polymer_number_range=5,
+        )
+        axis_positions, _ = readdy_post_processor.linear_fiber_axis_positions(
+            fiber_chain_ids=fiber_chain_ids,
+            ideal_positions=np.array(
+                [
+                    [24.738, 20.881, 26.671],
+                    [27.609, 24.061, 27.598],
+                    [30.382, 21.190, 25.725],
+                ]
+            ),
+            ideal_vector_to_axis=np.array(
+                [-0.01056751, -1.47785105, -0.65833209],
+            ),
+        )
+        fiber_points = readdy_post_processor.linear_fiber_control_points(
+            axis_positions=axis_positions,
+            segment_length=10.0,
+        )
+        fiber_points_array = np.array(fiber_points)
+        print(fiber_points_array.shape)
+        df_points = array_to_dataframe(fiber_points_array)
+        df_points.reset_index(inplace=True)
+        df_points.rename(columns={0: "xpos", 1: "ypos", 2: "zpos"}, inplace=True)
+        df_points["velocity"] = velocity
+        df_points["repeat"] = repeat
+        df_points["simulator"] = "readdy"
+        df_points["normalized_time"] = (df_points["time"] - df_points["time"].min()) / (
+            df_points["time"].max() - df_points["time"].min()
+        )
+        df_points.to_csv(
+            df_save_path,
+            index=False,
+        )
+        df_list.append(df_points)
+# %%
+df_readdy = pd.concat(df_list)
+df_readdy.to_csv(
+    readdy_df_path / "readdy_actin_compression_all_velocities_and_repeats.csv"
+)
+df_readdy.to_parquet(
+    readdy_df_path / "readdy_actin_compression_all_velocities_and_repeats.parquet"
+)
+
+# %%

--- a/subcell_analysis/postprocessing/readme.md
+++ b/subcell_analysis/postprocessing/readme.md
@@ -1,0 +1,12 @@
+# Post-processing of ReaDDy and Cytosim Outputs
+
+This document provides instructions on how to perform post-processing of ReaDDy and Cytosim outputs.
+
+## ReaDDy Output Post-processing
+
+1. **Step 1:** Obtain the ReaDDy output files. These files typically have the extension `.h5` or `.xml`.
+
+
+## Cytosim Output Post-processing
+
+1. **Step 1:** Obtain the cytosim output files. 

--- a/subcell_analysis/postprocessing/readme.md
+++ b/subcell_analysis/postprocessing/readme.md
@@ -4,9 +4,29 @@ This document provides instructions on how to perform post-processing of ReaDDy 
 
 ## ReaDDy Output Post-processing
 
-1. **Step 1:** Obtain the ReaDDy output files. These files typically have the extension `.h5` or `.xml`.
+Run `create_dataframes_from_readdy_outputs.py` to create dataframes from ReaDDy outputs. This script reads the ReaDDy output files and creates dataframes that can be used for further analysis.
+
+```bash
+python create_dataframes_from_readdy_outputs.py
+```
+The dataframes will be saved in the `data/dataframes/readdy` directory.
 
 
 ## Cytosim Output Post-processing
 
-1. **Step 1:** Obtain the cytosim output files. 
+Run `create_dataframes_from_cytosim_outputs.py` to create dataframes from Cytosim outputs. This script reads the Cytosim output files and creates dataframes that can be used for further analysis.
+```bash
+python create_dataframes_from_cytosim_outputs.py
+```
+The dataframes will be saved in the `data/dataframes/cytosim` directory.
+
+
+## Combining outputs
+
+Run `create_combined_dataframe.py` to combine ReaDDy and Cytosim outputs. This script reads the previously generated ReaDDy and Cytosim output files and combines them into a single dataframe.
+
+```bash
+python create_combined_dataframe.py
+```
+
+The combined dataframe will be saved in the `data/dataframes` directory.

--- a/subcell_analysis/readdy/readdy_post_processor.py
+++ b/subcell_analysis/readdy/readdy_post_processor.py
@@ -4,6 +4,7 @@ import math
 from typing import Dict, List, Tuple
 
 import numpy as np
+import pandas as pd
 
 from .readdy_data import FrameData
 
@@ -483,3 +484,23 @@ class ReaddyPostProcessor:
         for frame in self.trajectory:
             edges.append(frame.edges)
         return edges
+
+
+def array_to_dataframe(arr):
+    # Reshape the array to remove the singleton dimensions
+    arr = np.squeeze(arr)
+
+    # Reshape the array to have dimensions (timepoints * 50, 3)
+    reshaped_arr = arr.reshape(-1, 3)
+
+    # Create a DataFrame with timepoint and fiber point as multi-index
+    timepoints = np.repeat(range(arr.shape[0]), 50)
+    fiber_points = np.tile(range(50), arr.shape[0])
+
+    df = pd.DataFrame(reshaped_arr)
+    df["time"] = timepoints
+    df["id"] = fiber_points
+
+    df.set_index(["time", "id"], inplace=True)
+
+    return df

--- a/subcell_analysis/readdy/readdy_post_processor.py
+++ b/subcell_analysis/readdy/readdy_post_processor.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Tuple
 
 import numpy as np
 import pandas as pd
+from numpy import ndarray
 
 from .readdy_data import FrameData
 
@@ -486,16 +487,28 @@ class ReaddyPostProcessor:
         return edges
 
 
-def array_to_dataframe(arr):
+def array_to_dataframe(fiber_point_array: ndarray) -> pd.DataFrame:
+    """
+    Convert a 3D array to a pandas DataFrame.
+
+    Parameters
+    ----------
+    fiber_point_array: ndarray
+        The input 3D array.
+
+    Returns
+    -------
+    DataFrame: A pandas DataFrame with timepoint and fiber point as multi-index.
+    """
     # Reshape the array to remove the singleton dimensions
-    arr = np.squeeze(arr)
+    fiber_point_array = np.squeeze(fiber_point_array)
 
     # Reshape the array to have dimensions (timepoints * 50, 3)
-    reshaped_arr = arr.reshape(-1, 3)
+    reshaped_arr = fiber_point_array.reshape(-1, 3)
 
     # Create a DataFrame with timepoint and fiber point as multi-index
-    timepoints = np.repeat(range(arr.shape[0]), 50)
-    fiber_points = np.tile(range(50), arr.shape[0])
+    timepoints = np.repeat(range(fiber_point_array.shape[0]), 50)
+    fiber_points = np.tile(range(50), fiber_point_array.shape[0])
 
     df = pd.DataFrame(reshaped_arr)
     df["time"] = timepoints


### PR DESCRIPTION
Time Estimate or Size
=======
Medium to Large

Problem
=======
We need to convert raw outputs from cytosim and readdy into interpretable and interoperable formats to allow for visualization, metric calculation and other comparisons.

Also solves #13 

Solution
========
Adds postprocessing scripts to convert raw outputs from cytosim and readdy into dataframes.

## Type of change
* New feature (non-breaking change which adds functionality)

Change summary:
---------------
* Updated `compare_metric_plots.py` to plot metrics against real time
* Add script to subsample simulations (this is also in PR #23)
* Add bending energy and contour length metrics
* Simplify twist metric
* Add scripts to convert raw simulator outputs to dataframes, combine and save them.
* Update `pyproject.toml` to include additionaldependencies

Screenshots:
-----------------------
The dataframes are also saved in the `parquet` format which significantly reduces stroage space and loading time.
![image](https://github.com/simularium/subcell-analysis/assets/101426188/4781ab08-c807-4c74-95b9-fd2ae096eeea)


Keyfiles:
-----------------------
Refer to `subcell_analysis/postprocessing/readme.md`