### PR TITLE
Update autogenerated documentation to handle notebooks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,11 @@ jobs:
         conda env update --file environment.yml --prune
         pdm sync
 
+    - name: Convert notebook formats
+      shell: bash -l {0}
+      run: |
+        for FILE in $(find . -type f -name "_[a-z]*py"); do jupytext --sync $FILE; done
+
     - name: Generate documentation with Sphinx
       shell: bash -l {0}
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Convert notebook formats
       shell: bash -l {0}
       run: |
-        for FILE in $(find . -type f -name "_[a-z]*py"); do jupytext --sync $FILE; done
+        for FILE in $(find ./subcell_pipeline -type f -name "_[a-z]*py"); do jupytext --sync $FILE; done
 
     - name: Generate documentation with Sphinx
       shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Code style](https://simularium.github.io/subcell-pipeline/_badges/style.svg)](https://github.com/psf/black)
 [![License](https://simularium.github.io/subcell-pipeline/_badges/license.svg)](https://github.com/simularium/subcell-pipeline/blob/main/LICENSE)
 
-Analysis functionality for subcellular models
+Simulation, analysis, and visualization for subcellular models
 
 ---
 
@@ -56,31 +56,37 @@ Note that this installation method does not include the `readdy` package for Rea
 
 ## Usage
 
-### 1. Run Simulations
-The notebook aws_batch_job_submission.py can be used for configuring and executing simulations. Before this notebook can be succesfully executed, one must setup their AWSCLI credentials for submitting jobs and job definitions via the CLI. This notebook has five parts: 1a.) upload configuration files to s3, which involves generating the configuration files based on the template (vary_compress_rate.cym.tpl). Next, we have to create and register our job definition. In AWS Batch, a job definition specifies how many jobs are to be run, which docker image to use, how many CPUs to use, and the command a container should run when it is started.  We then submit our job to AWS using the submit_batch_job function. We can monitor these simulations as needed using check_batch_job. Finally, we can load in our results using the create_dataframes_for_repeats function which requires a bucket name, number of repeats, configs, and a save folder.
+The repository contains three major pipeline modules: `simulation`, `analysis`, and `visualization`.
 
-### 2. Post process to create dataframes from simulation data
-Involves running scripts in `subcell_analysis/postprocessing`. This also creates subsampled dataframes for further processing and metric calculation.
+### Simulations
 
-### 3. Tomography data analysis
-Selecting the tomogram filaments for analysis.
+The `simulation` module contains code for initializing, simulating, and post-processing simulations from different simulators.
+The module is further organized by simulator.
 
-### 3. Calculate metrics
+- [simulation.cytosim](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim) -- Simulations and processing for cytoskeleton simulation engine [Cytosim](https://gitlab.com/f-nedelec/cytosim)
+- [simulation.readdy](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/readdy) -- Simulations and processing for particle-based reaction-diffusion simulator [ReaDDy](https://readdy.github.io/)
 
-### 4. Visualize in simularium
+### Analysis
 
-### 5. Dimensionality reduction using PCA/PaCMAP
-Runs through generate_figure_data.ipynb
+The `analysis` module contains code for different analyses.
+Each analysis type contains a README with additional information:
 
+- [analysis.compression_metrics](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/analysis/compression_metrics)
+- [analysis.dimensionality_reduction](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/analysis/dimensionality_reduction)
+- [analysis.tomography_data](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/analysis/tomography_data)
 
-## Glossary of terms
-Definitions of some terms used in these analyses
-* *polymer trace*:
+### Visualization
 
-    refers to the line traced by a polymer backbone in three dimensions. For cytosim, this corresponds to the positions of the control points. For ReaDDy, this corresponds to a derived metric that traces the polymer backbone
+The `visualization` module contains code for visualizing simulation and analysis outputs.
 
-* *end-to-end axis*:
+## Glossary
 
-    refers to the line connecting the first and last points of a polymer trace
+Definitions of some terms used in this repo.
 
-**Apache Software License 2.0**
+- *polymer trace*
+
+    Refers to the line traced by a polymer backbone in three dimensions. For Cytosim, this corresponds to the positions of the control points. For ReaDDy, this corresponds to a derived metric that traces the polymer backbone
+
+- *end-to-end axis*
+
+    Refers to the line connecting the first and last points of a polymer trace

--- a/docs/_templates/custom_summary.rst
+++ b/docs/_templates/custom_summary.rst
@@ -1,0 +1,64 @@
+{{ fullname | custom_tocname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+   :members:
+   :undoc-members:
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Module Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+
+.. currentmodule:: {{module | custom_module }}
+
+.. autosummary::
+   :toctree:
+   :template: custom_summary.rst
+   :recursive:
+{% for item in modules %}
+   {{ item | custom_fullname }}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,8 @@ import os
 import sys
 from datetime import datetime
 
+from sphinx.ext.autosummary.generate import AutosummaryRenderer
+
 sys.path.insert(0, os.path.abspath("../subcell_pipeline"))
 
 # -- Project information -----------------------------------------------------
@@ -72,3 +74,33 @@ html_theme = "furo"
 
 # The name for this set of Sphinx documents.
 html_title = f"<strong>{project}</strong> <br />{release}"
+
+# -- Options for MyST --------------------------------------------------------
+
+# Automatically generate label slugs for header anchors
+myst_heading_anchors = 2
+
+# -- Patch custom template filters -------------------------------------------
+
+
+def custom_fullname_filter(fullname):
+    return ".".join(fullname.split(".")[1:])
+
+
+def custom_module_filter(module):
+    return module.split(".")[0]
+
+
+def custom_tocname_filter(fullname):
+    return ".".join(fullname.split(".")[1:])
+
+
+def patch_init(self, app):
+    AutosummaryRenderer.__original_init__(self, app)
+    self.env.filters["custom_fullname"] = custom_fullname_filter
+    self.env.filters["custom_module"] = custom_module_filter
+    self.env.filters["custom_tocname"] = custom_tocname_filter
+
+
+AutosummaryRenderer.__original_init__ = AutosummaryRenderer.__init__
+AutosummaryRenderer.__init__ = patch_init

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,12 @@
 
    Overview <self>
 
+.. toctree::
+   :hidden:
+   :caption: Workflow notebooks
+
+   Simulations <simulation>
+
 .. autosummary::
    :toctree: _summary
    :caption: API reference

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,10 +13,10 @@
 .. autosummary::
    :toctree: _summary
    :caption: API reference
+   :template: custom_summary.rst
    :recursive:
 
-   subcell_pipeline
-
+   subcell_pipeline.simulation
 
 .. toctree::
    :hidden:

--- a/docs/simulation.rst
+++ b/docs/simulation.rst
@@ -1,0 +1,8 @@
+Simulation workflow notebooks
+=============================
+
+.. include:: ../subcell_pipeline/simulation/cytosim/README.md
+   :parser: myst_parser.sphinx_
+
+.. include:: ../subcell_pipeline/simulation/readdy/README.md
+   :parser: myst_parser.sphinx_

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "lint", "dev", "test", "docs"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:769e0de24c25a322096420c5e9d4ca7d602ac52a2b5382fbdad447170cd970d4"
+content_hash = "sha256:a44304e4a75c0069b62e7aa6b0184948abfc853e8067ad4e274c1ce12737d12c"
 
 [[package]]
 name = "aiobotocore"
@@ -279,7 +279,7 @@ name = "attrs"
 version = "23.2.0"
 requires_python = ">=3.7"
 summary = "Classes Without Boilerplate"
-groups = ["default"]
+groups = ["default", "dev"]
 files = [
     {file = "attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"},
     {file = "attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"},
@@ -930,6 +930,16 @@ files = [
 ]
 
 [[package]]
+name = "fastjsonschema"
+version = "2.19.1"
+summary = "Fastest Python implementation of JSON schema"
+groups = ["dev"]
+files = [
+    {file = "fastjsonschema-2.19.1-py3-none-any.whl", hash = "sha256:3672b47bc94178c9f23dbb654bf47440155d4db9df5f7bc47643315f9c405cd0"},
+    {file = "fastjsonschema-2.19.1.tar.gz", hash = "sha256:e3126a94bdc4623d3de4485f8d468a12f02a67921315ddc87836d6e456dc789d"},
+]
+
+[[package]]
 name = "filelock"
 version = "3.14.0"
 requires_python = ">=3.8"
@@ -1484,7 +1494,7 @@ name = "jsonschema"
 version = "4.22.0"
 requires_python = ">=3.8"
 summary = "An implementation of JSON Schema validation for Python"
-groups = ["default"]
+groups = ["default", "dev"]
 dependencies = [
     "attrs>=22.2.0",
     "jsonschema-specifications>=2023.03.6",
@@ -1501,7 +1511,7 @@ name = "jsonschema-specifications"
 version = "2023.12.1"
 requires_python = ">=3.8"
 summary = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
-groups = ["default"]
+groups = ["default", "dev"]
 dependencies = [
     "referencing>=0.31.0",
 ]
@@ -1533,7 +1543,7 @@ name = "jupyter-core"
 version = "5.7.2"
 requires_python = ">=3.8"
 summary = "Jupyter core package. A base package on which Jupyter projects rely."
-groups = ["default"]
+groups = ["default", "dev"]
 dependencies = [
     "platformdirs>=2.5",
     "pywin32>=300; sys_platform == \"win32\" and platform_python_implementation != \"PyPy\"",
@@ -1542,6 +1552,25 @@ dependencies = [
 files = [
     {file = "jupyter_core-5.7.2-py3-none-any.whl", hash = "sha256:4f7315d2f6b4bcf2e3e7cb6e46772eba760ae459cd1f59d29eb57b0a01bd7409"},
     {file = "jupyter_core-5.7.2.tar.gz", hash = "sha256:aa5f8d32bbf6b431ac830496da7392035d6f61b4f54872f15c4bd2a9c3f536d9"},
+]
+
+[[package]]
+name = "jupytext"
+version = "1.16.2"
+requires_python = ">=3.8"
+summary = "Jupyter notebooks as Markdown documents, Julia, Python or R scripts"
+groups = ["dev"]
+dependencies = [
+    "markdown-it-py>=1.0",
+    "mdit-py-plugins",
+    "nbformat",
+    "packaging",
+    "pyyaml",
+    "tomli; python_version < \"3.11\"",
+]
+files = [
+    {file = "jupytext-1.16.2-py3-none-any.whl", hash = "sha256:197a43fef31dca612b68b311e01b8abd54441c7e637810b16b6cb8f2ab66065e"},
+    {file = "jupytext-1.16.2.tar.gz", hash = "sha256:8627dd9becbbebd79cc4a4ed4727d89d78e606b4b464eab72357b3b029023a14"},
 ]
 
 [[package]]
@@ -1672,7 +1701,7 @@ name = "markdown-it-py"
 version = "3.0.0"
 requires_python = ">=3.8"
 summary = "Python port of markdown-it. Markdown parsing, done right!"
-groups = ["default", "docs"]
+groups = ["default", "dev", "docs"]
 dependencies = [
     "mdurl~=0.1",
 ]
@@ -1767,7 +1796,7 @@ name = "mdit-py-plugins"
 version = "0.4.1"
 requires_python = ">=3.8"
 summary = "Collection of plugins for markdown-it-py"
-groups = ["docs"]
+groups = ["dev", "docs"]
 dependencies = [
     "markdown-it-py<4.0.0,>=1.0.0",
 ]
@@ -1781,7 +1810,7 @@ name = "mdurl"
 version = "0.1.2"
 requires_python = ">=3.7"
 summary = "Markdown URL utilities"
-groups = ["default", "docs"]
+groups = ["default", "dev", "docs"]
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
@@ -1882,6 +1911,23 @@ dependencies = [
 files = [
     {file = "myst_parser-3.0.1-py3-none-any.whl", hash = "sha256:6457aaa33a5d474aca678b8ead9b3dc298e89c68e67012e73146ea6fd54babf1"},
     {file = "myst_parser-3.0.1.tar.gz", hash = "sha256:88f0cb406cb363b077d176b51c476f62d60604d68a8dcdf4832e080441301a87"},
+]
+
+[[package]]
+name = "nbformat"
+version = "5.10.4"
+requires_python = ">=3.8"
+summary = "The Jupyter Notebook format"
+groups = ["dev"]
+dependencies = [
+    "fastjsonschema>=2.15",
+    "jsonschema>=2.6",
+    "jupyter-core!=5.0.*,>=4.12",
+    "traitlets>=5.1",
+]
+files = [
+    {file = "nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b"},
+    {file = "nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a"},
 ]
 
 [[package]]
@@ -2609,7 +2655,7 @@ files = [
 name = "pywin32"
 version = "306"
 summary = "Python for Window Extensions"
-groups = ["default"]
+groups = ["default", "dev"]
 marker = "sys_platform == \"win32\""
 files = [
     {file = "pywin32-306-cp310-cp310-win32.whl", hash = "sha256:06d3420a5155ba65f0b72f2699b5bacf3109f36acbe8923765c22938a69dfc8d"},
@@ -2742,7 +2788,7 @@ name = "referencing"
 version = "0.35.1"
 requires_python = ">=3.8"
 summary = "JSON Referencing + Python"
-groups = ["default"]
+groups = ["default", "dev"]
 dependencies = [
     "attrs>=22.2.0",
     "rpds-py>=0.7.0",
@@ -2872,7 +2918,7 @@ name = "rpds-py"
 version = "0.18.1"
 requires_python = ">=3.8"
 summary = "Python bindings to Rust's persistent data structures (rpds)"
-groups = ["default"]
+groups = ["default", "dev"]
 files = [
     {file = "rpds_py-0.18.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:d31dea506d718693b6b2cffc0648a8929bdc51c70a311b2770f09611caa10d53"},
     {file = "rpds_py-0.18.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:732672fbc449bab754e0b15356c077cc31566df874964d4801ab14f71951ea80"},
@@ -3486,7 +3532,7 @@ name = "traitlets"
 version = "5.14.3"
 requires_python = ">=3.8"
 summary = "Traitlets Python configuration system"
-groups = ["default"]
+groups = ["default", "dev"]
 files = [
     {file = "traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f"},
     {file = "traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "check-manifest>=0.49",
     "pre-commit>=3.7.1",
     "isort>=5.13.2",
+    "jupytext>=1.16.2",
 ]
 lint = [
     "black>=24.4.2",
@@ -130,3 +131,7 @@ ignore_missing_imports = true
 disallow_untyped_defs = true
 check_untyped_defs = true
 show_error_codes = true
+
+[tool.jupytext.formats]
+"docs/_notebooks/" = "md"
+"subcell_pipeline/" = "py:percent"

--- a/requirements.txt
+++ b/requirements.txt
@@ -340,6 +340,9 @@ exceptiongroup==1.2.1; python_version < "3.11" \
 executing==2.0.1 \
     --hash=sha256:35afe2ce3affba8ee97f2d69927fa823b08b472b7b994e36a52a964b93d16147 \
     --hash=sha256:eac49ca94516ccc753f9fb5ce82603156e590b27525a8bc32cce8ae302eb61bc
+fastjsonschema==2.19.1 \
+    --hash=sha256:3672b47bc94178c9f23dbb654bf47440155d4db9df5f7bc47643315f9c405cd0 \
+    --hash=sha256:e3126a94bdc4623d3de4485f8d468a12f02a67921315ddc87836d6e456dc789d
 filelock==3.14.0 \
     --hash=sha256:43339835842f110ca7ae60f1e1c160714c5a6afd15a2873419ab185334975c0f \
     --hash=sha256:6ea72da3be9b8c82afd3edcf99f2fffbb5076335a5ae4d03248bb5b6c3eae78a
@@ -520,6 +523,9 @@ jupyter-client==8.6.2 \
 jupyter-core==5.7.2 \
     --hash=sha256:4f7315d2f6b4bcf2e3e7cb6e46772eba760ae459cd1f59d29eb57b0a01bd7409 \
     --hash=sha256:aa5f8d32bbf6b431ac830496da7392035d6f61b4f54872f15c4bd2a9c3f536d9
+jupytext==1.16.2 \
+    --hash=sha256:197a43fef31dca612b68b311e01b8abd54441c7e637810b16b6cb8f2ab66065e \
+    --hash=sha256:8627dd9becbbebd79cc4a4ed4727d89d78e606b4b464eab72357b3b029023a14
 kiwisolver==1.4.5 \
     --hash=sha256:040c1aebeda72197ef477a906782b5ab0d387642e93bda547336b8957c61022e \
     --hash=sha256:05703cf211d585109fcd72207a31bb170a0f22144d68298dc5e61b3c946518af \
@@ -692,6 +698,9 @@ mypy-extensions==1.0.0 \
 myst-parser==3.0.1 \
     --hash=sha256:6457aaa33a5d474aca678b8ead9b3dc298e89c68e67012e73146ea6fd54babf1 \
     --hash=sha256:88f0cb406cb363b077d176b51c476f62d60604d68a8dcdf4832e080441301a87
+nbformat==5.10.4 \
+    --hash=sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a \
+    --hash=sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b
 nest-asyncio==1.6.0 \
     --hash=sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe \
     --hash=sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c

--- a/subcell_pipeline/simulation/__init__.py
+++ b/subcell_pipeline/simulation/__init__.py
@@ -1,0 +1,1 @@
+"""Simulation methods and notebooks."""

--- a/subcell_pipeline/simulation/batch_simulations.py
+++ b/subcell_pipeline/simulation/batch_simulations.py
@@ -1,3 +1,7 @@
+"""
+Methods for running simulations on AWS Batch.
+"""
+
 import re
 
 import boto3
@@ -125,21 +129,21 @@ def register_and_run_simulations(
         Current timestamp used to organize input and outfile files.
     group_keys
         List of config group keys.
-    aws_account : str
+    aws_account
         AWS account number.
-    aws_region : str
+    aws_region
         AWS region.
-    aws_user : str
+    aws_user
         User name prefix for job name and image.
-    image : str
+    image
         Image name and version.
-    vcpus : int
+    vcpus
         Number of vCPUs for each job.
-    memory : int
+    memory
         Memory for each job.
-    job_queue : str
+    job_queue
         Job queue.
-    job_size : int
+    job_size
         Job array size.
 
     Returns
@@ -202,7 +206,7 @@ def check_and_save_job_logs(
         Name of simulation series.
     job_arns
         List of job ARNs.
-    aws_region : str
+    aws_region
         AWS region.
     """
 

--- a/subcell_pipeline/simulation/batch_simulations.py
+++ b/subcell_pipeline/simulation/batch_simulations.py
@@ -1,6 +1,4 @@
-"""
-Methods for running simulations on AWS Batch.
-"""
+"""Methods for running simulations on AWS Batch."""
 
 import re
 

--- a/subcell_pipeline/simulation/cytosim/README.md
+++ b/subcell_pipeline/simulation/cytosim/README.md
@@ -7,7 +7,7 @@ Simulations and processing for cytoskeleton simulation engine [Cytosim](https://
 
 ## Baseline single actin fiber with no compression
 
-The `SINGLE_FIBER` simulation series simulates a single actin fiber with a free barbed end across five replicates.
+The `NO_COMPRESSION` simulation series simulates a single actin fiber with a free barbed end across five replicates.
 
 - **Run Cytosim single fiber simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim/_run_cytosim_no_compression_batch_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/cytosim/_run_cytosim_no_compression_batch_simulations.html))
 - **Process Cytosim single fiber simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim/_process_cytosim_no_compression_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/cytosim/_process_cytosim_no_compression_simulations.html))

--- a/subcell_pipeline/simulation/cytosim/README.md
+++ b/subcell_pipeline/simulation/cytosim/README.md
@@ -5,12 +5,12 @@ Simulations and processing for cytoskeleton simulation engine [Cytosim](https://
 > - **Base simulator**: [https://gitlab.com/f-nedelec/cytosim](https://gitlab.com/f-nedelec/cytosim)
 > - **Model development**: [https://github.com/simularium/Cytosim](https://github.com/simularium/Cytosim)
 
-## Baseline single actin fiber
+## Baseline single actin fiber with no compression
 
 The `SINGLE_FIBER` simulation series simulates a single actin fiber with a free barbed end across five replicates.
 
-- **Run Cytosim single fiber simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim/_run_cytosim_single_fiber_batch_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/cytosim/_run_cytosim_single_fiber_batch_simulations.html))
-- **Process Cytosim single fiber simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim/_process_cytosim_single_fiber_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/cytosim/_process_cytosim_single_fiber_simulations.html))
+- **Run Cytosim single fiber simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim/_run_cytosim_no_compression_batch_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/cytosim/_run_cytosim_no_compression_batch_simulations.html))
+- **Process Cytosim single fiber simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim/_process_cytosim_no_compression_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/cytosim/_process_cytosim_no_compression_simulations.html))
 
 ## Single actin fiber compressed at different compression velocities
 

--- a/subcell_pipeline/simulation/cytosim/README.md
+++ b/subcell_pipeline/simulation/cytosim/README.md
@@ -1,0 +1,20 @@
+# Cytosim simulations
+
+Simulations and processing for cytoskeleton simulation engine [Cytosim](https://gitlab.com/f-nedelec/cytosim).
+
+> - **Base simulator**: [https://gitlab.com/f-nedelec/cytosim](https://gitlab.com/f-nedelec/cytosim)
+> - **Model development**: [https://github.com/simularium/Cytosim](https://github.com/simularium/Cytosim)
+
+## Baseline single actin fiber
+
+The `SINGLE_FIBER` simulation series simulates a single actin fiber with a free barbed end across five replicates.
+
+- **Run Cytosim single fiber simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim/_run_cytosim_single_fiber_batch_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/cytosim/_run_cytosim_single_fiber_batch_simulations.html))
+- **Process Cytosim single fiber simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim/_process_cytosim_single_fiber_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/cytosim/_process_cytosim_single_fiber_simulations.html))
+
+## Single actin fiber compressed at different compression velocities
+
+The `COMPRESSION_VELOCITY` simulation series simulates compression of a single 500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with five replicates.
+
+- **Run Cytosim compression simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim/_run_cytosim_compression_batch_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/cytosim/_run_cytosim_compression_batch_simulations.html))
+- **Process Cytosim compression simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim/_process_cytosim_compression_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/cytosim/_process_cytosim_compression_simulations.html))

--- a/subcell_pipeline/simulation/cytosim/__init__.py
+++ b/subcell_pipeline/simulation/cytosim/__init__.py
@@ -1,0 +1,1 @@
+"""Simulation methods and notebooks for Cytosim."""

--- a/subcell_pipeline/simulation/cytosim/_process_cytosim_compression_simulations.py
+++ b/subcell_pipeline/simulation/cytosim/_process_cytosim_compression_simulations.py
@@ -18,6 +18,10 @@ multiple replicates, see `process_cytosim_no_compression_simulations.py`.
 """
 
 # %%
+if __name__ != "__main__":
+    raise ImportError("This module is a notebook and is not meant to be imported")
+
+# %%
 from subcell_pipeline.simulation.cytosim.post_processing import (
     parse_cytosim_simulation_data,
 )
@@ -28,8 +32,8 @@ from subcell_pipeline.simulation.post_processing import sample_simulation_data
 ## Define simulation conditions
 
 Defines the `COMPRESSION_VELOCITY` simulation series, which compresses a single
-500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 $\mu m$/s)
-with five replicates each (random seeds 1, 2, 3, 4, and 5).
+500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with
+five replicates each (random seeds 1, 2, 3, 4, and 5).
 """
 
 # %%
@@ -90,5 +94,3 @@ condition key and random seed already exists, sampling is skipped.
 sample_simulation_data(
     bucket, series_name, condition_keys, random_seeds, n_timepoints, n_monomer_points
 )
-
-# %%

--- a/subcell_pipeline/simulation/cytosim/_process_cytosim_no_compression_simulations.py
+++ b/subcell_pipeline/simulation/cytosim/_process_cytosim_no_compression_simulations.py
@@ -18,6 +18,10 @@ series with multiple conditions, each of which have multiple replicates, see
 """
 
 # %%
+if __name__ != "__main__":
+    raise ImportError("This module is a notebook and is not meant to be imported")
+
+# %%
 from subcell_pipeline.simulation.cytosim.post_processing import (
     parse_cytosim_simulation_data,
 )
@@ -87,5 +91,3 @@ condition key and random seed already exists, sampling is skipped.
 sample_simulation_data(
     bucket, series_name, [""], random_seeds, n_timepoints, n_monomer_points
 )
-
-# %%

--- a/subcell_pipeline/simulation/cytosim/_run_cytosim_compression_batch_simulations.py
+++ b/subcell_pipeline/simulation/cytosim/_run_cytosim_compression_batch_simulations.py
@@ -1,7 +1,8 @@
 # %% [markdown]
-"""
-# Run Cytosim compression simulations
+# # Run Cytosim compression simulations
 
+# %% [markdown]
+"""
 Notebook contains steps for running Cytosim simulations in which a single actin
 fiber is compressed at different compression velocities.
 
@@ -19,7 +20,11 @@ multiple replicates, see `run_cytosim_no_compression_batch_simulations.py`.
 - [Define simulation settings](#define-simulation-settings)
 - [Register and run jobs](#register-and-run-jobs)
 - [Check and save job logs](#check-and-save-job-logs)
-"""  # noqa: D400, D415
+"""
+
+# %%
+if __name__ != "__main__":
+    raise ImportError("This module is a notebook and is not meant to be imported")
 
 # %%
 import getpass
@@ -56,8 +61,8 @@ from preconfig import Preconfig  # noqa: E402
 ## Define simulation conditions
 
 Defines the `COMPRESSION_VELOCITY` simulation series, which compresses a single
-500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 $\mu m$/s)
-with five replicates each (random seeds 1, 2, 3, 4, and 5).
+500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with
+five replicates each (random seeds 1, 2, 3, 4, and 5).
 """
 
 # %%

--- a/subcell_pipeline/simulation/cytosim/_run_cytosim_no_compression_batch_simulations.py
+++ b/subcell_pipeline/simulation/cytosim/_run_cytosim_no_compression_batch_simulations.py
@@ -1,7 +1,8 @@
 # %% [markdown]
-"""
-# Run Cytosim no compression simulations
+# # Run Cytosim no compression simulations
 
+# %% [markdown]
+"""
 Notebook contains steps for running Cytosim simulations for a baseline single
 actin fiber with no compression.
 
@@ -19,7 +20,11 @@ see `run_cytosim_compression_batch_simulations.py`.
 - [Define simulation settings](#define-simulation-settings)
 - [Register and run jobs](#register-and-run-jobs)
 - [Check and save job logs](#check-and-save-job-logs)
-"""  # noqa: D400, D415
+"""
+
+# %%
+if __name__ != "__main__":
+    raise ImportError("This module is a notebook and is not meant to be imported")
 
 # %%
 import getpass

--- a/subcell_pipeline/simulation/cytosim/post_processing.py
+++ b/subcell_pipeline/simulation/cytosim/post_processing.py
@@ -1,6 +1,4 @@
-"""
-Methods for processing Cytosim simulations.
-"""
+"""Methods for processing Cytosim simulations."""
 
 from typing import Union
 

--- a/subcell_pipeline/simulation/cytosim/post_processing.py
+++ b/subcell_pipeline/simulation/cytosim/post_processing.py
@@ -1,3 +1,7 @@
+"""
+Methods for processing Cytosim simulations.
+"""
+
 from typing import Union
 
 import numpy as np
@@ -53,7 +57,7 @@ def parse_cytosim_simulation_data(
         Name of S3 bucket for input and output files.
     series_name
         Name of simulation series.
-    condition_keys : list[str]
+    condition_keys
         List of condition keys.
     random_seeds
         Random seeds for simulations.

--- a/subcell_pipeline/simulation/post_processing.py
+++ b/subcell_pipeline/simulation/post_processing.py
@@ -1,3 +1,7 @@
+"""
+Methods for processing simulations.
+"""
+
 import numpy as np
 import pandas as pd
 from io_collection.keys.check_key import check_key
@@ -24,7 +28,7 @@ def sample_simulation_data(
         Name of S3 bucket for input and output files.
     series_name
         Name of simulation series.
-    condition_keys : list[str]
+    condition_keys
         List of condition keys.
     random_seeds
         Random seeds for simulations.

--- a/subcell_pipeline/simulation/post_processing.py
+++ b/subcell_pipeline/simulation/post_processing.py
@@ -1,6 +1,4 @@
-"""
-Methods for processing simulations.
-"""
+"""Methods for processing simulations."""
 
 import numpy as np
 import pandas as pd

--- a/subcell_pipeline/simulation/readdy/README.md
+++ b/subcell_pipeline/simulation/readdy/README.md
@@ -1,0 +1,6 @@
+# ReaDDy simulations
+
+Simulations and processing for particle-based reaction-diffusion simulator [ReaDDy](https://readdy.github.io/).
+
+> - **Base simulator**: [https://github.com/readdy/readdy](https://github.com/readdy/readdy)
+> - **Model development**: [https://github.com/simularium/readdy-models](https://github.com/simularium/readdy-models)


### PR DESCRIPTION
_Estimated size: medium_

Update how documentation is generated, so that (1) notebooks (now with a `_` prefix) are converted to Markdown and ignored by Sphinx autodoc and (2) modules are not converted to Markdown and included in Sphinx autodoc.

# Summary of changes

- Rename existing simulation notebooks to have `_` prefix
- Add an explicit check for `if __name__ != "__main__"` in notebooks to prevent them from being imported (and therefore running the entire notebook)
- Add custom template for autodoc
- Add `jupytext` to dependencies

# Steps to verify

1. Run `for FILE in $(find . -type f -name "_[a-z]*py"); do jupytext --sync $FILE; done` which will generate Markdown versions of the notebooks in the docs folder
2. Run `make docs` which will generate the docs  (view the `docs/_build/html/index.html` file in a browser) -- note that none of the source/notebook links will work until this PR is merged