### PR TITLE
Add wall clock time analysis for Cytosim

### DIFF
--- a/subcell_pipeline/analysis/wall_clock_time/README.md
+++ b/subcell_pipeline/analysis/wall_clock_time/README.md
@@ -1,0 +1,7 @@
+# Wall clock times
+
+## Single actin fiber compressed at different compression velocities
+
+Analysis extracts wall clock times from the `COMPRESSION_VELOCITY` simulation series, which simulates compression of a single 500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with five replicates.
+
+- **Summarize Cytosim compression simulation wall clock times** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/analysis/wall_clock_time/_summarize_cytosim_compression_simulation_wall_clock_times.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/analysis/wall_clock_time/_summarize_cytosim_compression_simulation_wall_clock_times.html))

--- a/subcell_pipeline/analysis/wall_clock_time/__init__.py
+++ b/subcell_pipeline/analysis/wall_clock_time/__init__.py
@@ -1,0 +1,1 @@
+"""Wall clock time analysis methods and notebooks."""

--- a/subcell_pipeline/analysis/wall_clock_time/_summarize_cytosim_compression_simulation_wall_clock_times.py
+++ b/subcell_pipeline/analysis/wall_clock_time/_summarize_cytosim_compression_simulation_wall_clock_times.py
@@ -1,0 +1,76 @@
+# %% [markdown]
+# # Summarize Cytosim compression simulation wall clock times
+
+# %% [markdown]
+"""
+Notebook contains steps for extracting wall clock time for Cytosim simulations
+in which a single actin fiber is compressed at different compression
+velocities.
+
+- [Define simulation conditions](#define-simulation-conditions)
+- [Extract wall clock time from logs](#extract-wall-clock-time-from-logs)
+"""
+
+# %%
+if __name__ != "__main__":
+    raise ImportError("This module is a notebook and is not meant to be imported")
+
+# %%
+from io_collection.save.save_dataframe import save_dataframe
+
+from subcell_pipeline.analysis.wall_clock_time.log_data import (
+    get_wall_clock_time_from_logs,
+)
+
+# %% [markdown]
+"""
+## Define simulation conditions
+
+Defines the `COMPRESSION_VELOCITY` simulation series, which compresses a single
+500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with
+five replicates each (random seeds 1, 2, 3, 4, and 5).
+"""
+
+# %%
+# Name of the simulation series
+series_name: str = "COMPRESSION_VELOCITY"
+
+# S3 bucket for input and output files
+bucket: str = "s3://cytosim-working-bucket"
+
+# Random seeds for simulations
+random_seeds: list[int] = [1, 2, 3, 4, 5]
+
+# List of condition file keys for each velocity
+condition_keys: list[str] = ["0047", "0150", "0470", "1500"]
+
+# Job ARN
+job_arns: dict = {
+    "0047": "c1210f24-d2d4-47ee-84c5-c0bbcd6d6d1a",
+    "0150": "bab2b1b2-8159-412b-bfee-9ed5f5ee53d8",
+    "0470": "b57fdc74-a1f8-45df-867b-492c99009b46",
+    "1500": "36d1198f-16cc-4564-ae30-a2944753c143",
+}
+
+# Pattern for finding wall clock time in logs
+pattern = "end\s+([0-9]+) s"
+
+# %% [markdown]
+"""
+## Extract wall clock time from logs
+
+Iterate through all the logs and extract wall clock time using the specified
+regex pattern.
+"""
+
+# %%
+logs = get_wall_clock_time_from_logs(
+    bucket, series_name, condition_keys, random_seeds, job_arns, pattern
+)
+
+# %%
+wall_clock_time_key = f"{series_name}/analysis/{series_name}_wall_clock_times.csv"
+save_dataframe(bucket, wall_clock_time_key, logs)
+
+# %%
+print(logs.groupby("condition")["time"].describe())

--- a/subcell_pipeline/analysis/wall_clock_time/log_data.py
+++ b/subcell_pipeline/analysis/wall_clock_time/log_data.py
@@ -1,0 +1,37 @@
+import re
+
+import pandas as pd
+from io_collection.load.load_text import load_text
+
+
+def get_wall_clock_time_from_logs(
+    bucket: str,
+    series_name: str,
+    condition_keys: list[str],
+    random_seeds: list[int],
+    job_arns: dict,
+    pattern: str,
+) -> pd.DataFrame:
+
+    wall_clock_times: list[dict] = []
+
+    for condition_key in condition_keys:
+        series_key = f"{series_name}_{condition_key}" if condition_key else series_name
+        job_arn = job_arns[condition_key]
+
+        for index, seed in enumerate(random_seeds):
+            log_key = f"{series_name}/logs/{series_key}_{job_arn}:{index}.log"
+            print(f"Extracting wall clock time from [ {log_key} ]")
+
+            log = load_text(bucket, log_key)
+            time = re.findall(pattern, log)[0]
+
+            wall_clock_times.append(
+                {
+                    "condition": condition_key,
+                    "seed": seed,
+                    "time": int(time),
+                }
+            )
+
+    return pd.DataFrame(wall_clock_times)

--- a/subcell_pipeline/analysis/wall_clock_time/log_data.py
+++ b/subcell_pipeline/analysis/wall_clock_time/log_data.py
@@ -12,6 +12,29 @@ def get_wall_clock_time_from_logs(
     job_arns: dict,
     pattern: str,
 ) -> pd.DataFrame:
+    """
+    Extract wall clock times from log files.
+
+    Parameters
+    ----------
+    bucket
+        Name of S3 bucket for input and output files.
+    series_name
+        Name of simulation series.
+    condition_keys
+        List of condition keys.
+    random_seeds
+        Random seeds for simulations.
+    job_arns
+        Map of conditions to job ARNs.
+    pattern
+        Regex pattern to find wall clock time in log text.
+
+    Returns
+    -------
+    :
+        Dataframe of wall clock times.
+    """
 
     wall_clock_times: list[dict] = []
 

--- a/subcell_pipeline/simulation/batch_simulations.py
+++ b/subcell_pipeline/simulation/batch_simulations.py
@@ -228,5 +228,5 @@ def check_and_save_job_logs(
 
             print(f"Saving logs for job [ {response['jobId']} ] to [ {log_key}]")
 
-            logs = get_batch_logs(response["jobArn"], ".")
+            logs = get_batch_logs(response["jobArn"], " ")
             save_text(bucket, log_key, logs)


### PR DESCRIPTION
_Estimated size: small_

Resolves #30. Add analysis workflow to extract Cytosim wall clock times from the saved logs. Workflow saves the wall clock times to S3.

# Summary of changes

- Add notebook for Cytosim wall clock times analysis
- Fix log pattern filter for Batch logs (and re-ran for the existing simulations)

# Steps to verify

1. Run `_summarize_cytosim_compression_simulation_wall_clock_times.py` 