### PR TITLE
Add save methods to analysis workflows

### DIFF
--- a/subcell_pipeline/analysis/compression_metrics/_compare_compression_metrics.py
+++ b/subcell_pipeline/analysis/compression_metrics/_compare_compression_metrics.py
@@ -11,6 +11,7 @@ simulators. Currently supports comparison of Cytosim and ReaDDy simulations.
 - [Calculate metrics for Cytosim data](#calculate-metrics-for-cytosim-data)
 - [Calculate metrics for ReaDDy data](#calculate-metrics-for-readdy-data)
 - [Combine metrics from both simulators](#combine-metrics-from-both-simulators)
+- [Save combined compression metrics](#save-combined-compression-metrics)
 - [Plot metrics vs time](#plot-metrics-vs-time)
 """
 
@@ -26,6 +27,7 @@ import pandas as pd
 from subcell_pipeline.analysis.compression_metrics.compression_analysis import (
     get_compression_metric_data,
     plot_metrics_vs_time,
+    save_compression_metrics,
 )
 from subcell_pipeline.analysis.compression_metrics.compression_metric import (
     CompressionMetric,
@@ -84,7 +86,6 @@ metrics = [
 # %% [markdown]
 """
 ## Calculate metrics for Cytosim data
-
 """
 
 # %%
@@ -101,7 +102,6 @@ cytosim_metrics["simulator"] = "cytosim"
 # %% [markdown]
 """
 ## Calculate metrics for ReaDDy data
-
 """
 
 # %%
@@ -118,7 +118,6 @@ readdy_metrics["simulator"] = "readdy"
 # %% [markdown]
 """
 ## Combine metrics from both simulators
-
 """
 
 # %%
@@ -128,8 +127,18 @@ combined_metrics["velocity"] = combined_metrics["key"].astype("int") / 10
 
 # %% [markdown]
 """
-## Plot metrics vs time
+## Save combined compression metrics
+"""
 
+# %%
+save_compression_metrics(
+    combined_metrics, str(save_location), "actin_compression_combined_metrics.csv"
+)
+
+
+# %% [markdown]
+"""
+## Plot metrics vs time
 """
 
 # %%

--- a/subcell_pipeline/analysis/compression_metrics/compression_analysis.py
+++ b/subcell_pipeline/analysis/compression_metrics/compression_analysis.py
@@ -134,6 +134,25 @@ def calculate_compression_metrics(
     return df_metrics.reset_index().rename(columns={"index": "time"})
 
 
+def save_compression_metrics(
+    data: pd.DataFrame, save_location: str, save_key: str
+) -> None:
+    """
+    Save combined compression metrics data.
+
+    Parameters
+    ----------
+    data
+        Compression metrics data.
+    save_location
+        Location for output file (local path or S3 bucket).
+    save_key
+        Name key for output file.
+    """
+
+    save_dataframe(save_location, save_key, data, index=False)
+
+
 def plot_metrics_vs_time(
     df: pd.DataFrame,
     metrics: List[CompressionMetric],

--- a/subcell_pipeline/analysis/dimensionality_reduction/_run_pca_on_compression_simulations.py
+++ b/subcell_pipeline/analysis/dimensionality_reduction/_run_pca_on_compression_simulations.py
@@ -13,6 +13,7 @@ the positive y axis, keeping x axis coordinates unchanged, before running PCA.
 - [Save aligned fibers](#save-aligned-fibers)
 - [Plot aligned fibers](#plot-aligned-fibers)
 - [Run PCA](#run-pca)
+- [Save PCA results](#save-pca-results)
 - [Save PCA trajectories](#save-pca-trajectories)
 - [Save PCA transforms](#save-pca-transforms)
 - [Plot PCA feature scatter](#plot-pca-feature-scatter)
@@ -37,6 +38,7 @@ from subcell_pipeline.analysis.dimensionality_reduction.pca_dim_reduction import
     plot_pca_feature_scatter,
     plot_pca_inverse_transform,
     run_pca,
+    save_pca_results,
     save_pca_trajectories,
     save_pca_transforms,
 )
@@ -132,6 +134,14 @@ pca_results, pca = run_pca(data)
 
 # %% [markdown]
 """
+## Save PCA results
+"""
+
+# %%
+save_pca_results(pca_results, save_location, "actin_compression_pca_results.csv")
+
+# %% [markdown]
+"""
 ## Save PCA trajectories
 """
 # %%
@@ -144,7 +154,7 @@ save_pca_trajectories(
 ## Save PCA transforms
 """
 # %%
-points = [
+points: list[list[float]] = [
     [-600, -300, 0, 300, 600, 900],
     [-200, 0, 200, 400],
 ]

--- a/subcell_pipeline/analysis/dimensionality_reduction/_run_pca_on_compression_simulations.py
+++ b/subcell_pipeline/analysis/dimensionality_reduction/_run_pca_on_compression_simulations.py
@@ -135,10 +135,15 @@ pca_results, pca = run_pca(data)
 # %% [markdown]
 """
 ## Save PCA results
+
+The PCA results are saved with resampled rows, which shuffles the order of the
+entries. Pre-shuffled data is useful for scatter plots showing each individual
 """
 
 # %%
-save_pca_results(pca_results, save_location, "actin_compression_pca_results.csv")
+save_pca_results(
+    pca_results, save_location, "actin_compression_pca_results.csv", resample=True
+)
 
 # %% [markdown]
 """

--- a/subcell_pipeline/analysis/dimensionality_reduction/pca_dim_reduction.py
+++ b/subcell_pipeline/analysis/dimensionality_reduction/pca_dim_reduction.py
@@ -56,7 +56,7 @@ def save_pca_results(
     save_key
         Name key for output file.
     resample : bool
-        True is data should be resampled before saving, False otherwise.
+        True if data should be resampled before saving, False otherwise.
     """
 
     if resample:

--- a/subcell_pipeline/analysis/dimensionality_reduction/pca_dim_reduction.py
+++ b/subcell_pipeline/analysis/dimensionality_reduction/pca_dim_reduction.py
@@ -5,6 +5,7 @@ import random
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from io_collection.save.save_dataframe import save_dataframe
 from io_collection.save.save_json import save_json
 from sklearn.decomposition import PCA
 
@@ -36,9 +37,32 @@ def run_pca(data: pd.DataFrame) -> tuple[pd.DataFrame, PCA]:
         [pd.DataFrame(transform, columns=["PCA1", "PCA2"]), all_features],
         axis=1,
     )
-    pca_results = pca_results.sample(frac=1, random_state=1)
 
     return pca_results, pca
+
+
+def save_pca_results(
+    pca_results: pd.DataFrame, save_location: str, save_key: str, resample: bool = True
+) -> None:
+    """
+    Save PCA results data.
+
+    Parameters
+    ----------
+    pca_results
+        PCA trajectory data.
+    save_location
+        Location for output file (local path or S3 bucket).
+    save_key
+        Name key for output file.
+    resample : bool
+        True is data should be resampled before saving, False otherwise.
+    """
+
+    if resample:
+        pca_results = pca_results.copy().sample(frac=1.0, random_state=1)
+
+    save_dataframe(save_location, save_key, pca_results, index=False)
 
 
 def save_pca_trajectories(


### PR DESCRIPTION
_Estimated size: xsmall_

Add two additional save methods to the compression metrics and PCA workflows. These outputs are used to generate figures.