### PR TITLE
Update Cytosim series name and make figure saving consistent across workflows

### DIFF
--- a/subcell_pipeline/analysis/compression_metrics/_compare_compression_metrics.py
+++ b/subcell_pipeline/analysis/compression_metrics/_compare_compression_metrics.py
@@ -13,6 +13,7 @@ simulators. Currently supports comparison of Cytosim and ReaDDy simulations.
 - [Combine metrics from both simulators](#combine-metrics-from-both-simulators)
 - [Save combined compression metrics](#save-combined-compression-metrics)
 - [Plot metrics vs time](#plot-metrics-vs-time)
+- [Plot metrics histograms](#plot-metrics-histograms)
 """
 
 # %%
@@ -20,8 +21,6 @@ if __name__ != "__main__":
     raise ImportError("This module is a notebook and is not meant to be imported")
 
 # %%
-from pathlib import Path
-
 import pandas as pd
 
 from subcell_pipeline.analysis.compression_metrics.compression_analysis import (
@@ -61,9 +60,8 @@ random_seeds: list[int] = [1, 2, 3, 4, 5]
 # List of condition file keys for each velocity
 condition_keys: list[str] = ["0047", "0150", "0470", "1500"]
 
-# Location to save plot of metrics vs time (local path)
-save_location: Path = Path(__file__).parents[3] / "analysis_outputs"
-save_location.mkdir(parents=True, exist_ok=True)
+# Location to save analysis results (S3 bucket or local path)
+save_location: str = "s3://subcell-working-bucket"
 
 # Specify whether the metrics should be recalculated. Set this to true if you
 # make changes to any metric calculation functions.
@@ -159,7 +157,9 @@ combined_metrics["velocity"] = combined_metrics["key"].astype("int") / 10
 
 # %%
 save_compression_metrics(
-    combined_metrics, str(save_location), "actin_compression_combined_metrics.csv"
+    combined_metrics,
+    save_location,
+    "compression_metrics/actin_compression_combined_metrics.csv",
 )
 
 # %% [markdown]
@@ -171,14 +171,19 @@ save_compression_metrics(
 plot_metrics_vs_time(
     df=combined_metrics,
     metrics=metrics,
-    figure_path=save_location,
-    suffix="_subsampled",
+    save_location=save_location,
+    save_key_template="compression_metrics/actin_compression_metrics_over_time_subsampled_%s.png",
 )
+
+# %% [markdown]
+"""
+## Plot metrics histograms
+"""
 
 # %%
 plot_metric_distribution(
     df=combined_metrics,
     metrics=metrics,
-    figure_path=save_location,
-    suffix="_subsampled",
+    save_location=save_location,
+    save_key_template="compression_metrics/actin_compression_metrics_histograms_subsampled_%s.png",
 )

--- a/subcell_pipeline/analysis/compression_metrics/_compare_compression_metrics.py
+++ b/subcell_pipeline/analysis/compression_metrics/_compare_compression_metrics.py
@@ -37,16 +37,17 @@ from subcell_pipeline.analysis.compression_metrics.compression_metric import (
 """
 ## Define simulation conditions
 
-Defines the `COMPRESSION_VELOCITY` simulation series, which compresses a single
-500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with
-five replicates each and the baseline `NO_COMPRESSION` simulation series, which
-simulates a single actin fiber with a free barbed end across five replicates.
+Defines the `ACTIN_COMPRESSION_VELOCITY` simulation series, which compresses a
+single 500 nm actin fiber at four different velocities (4.7, 15, 47, and 150
+μm/s) with five replicates each and the baseline `ACTIN_NO_COMPRESSION`
+simulation series, which simulates a single actin fiber with a free barbed end
+across five replicates.
 """
 
 # %%
 # Name of the simulation series
-compression_series_name: str = "COMPRESSION_VELOCITY"
-no_compression_series_name: str = "NO_COMPRESSION"
+compression_series_name: str = "ACTIN_COMPRESSION_VELOCITY"
+no_compression_series_name: str = "ACTIN_NO_COMPRESSION"
 
 # S3 bucket Cytosim for input and output files
 cytosim_bucket: str = "s3://cytosim-working-bucket"
@@ -65,7 +66,7 @@ save_location: str = "s3://subcell-working-bucket"
 
 # Specify whether the metrics should be recalculated. Set this to true if you
 # make changes to any metric calculation functions.
-recalculate: bool = True
+recalculate: bool = False
 
 # %% [markdown]
 """
@@ -121,7 +122,7 @@ cytosim_metrics_no_compression["simulator"] = "cytosim"
 # %%
 readdy_metrics_compression = get_compression_metric_data(
     bucket=readdy_bucket,
-    series_name=f"ACTIN_{compression_series_name}",
+    series_name=compression_series_name,
     condition_keys=condition_keys,
     random_seeds=random_seeds,
     metrics=metrics,
@@ -132,7 +133,7 @@ readdy_metrics_compression["simulator"] = "readdy"
 # %%
 readdy_metrics_no_compression = get_compression_metric_data(
     bucket=readdy_bucket,
-    series_name=f"ACTIN_{no_compression_series_name}",
+    series_name=no_compression_series_name,
     condition_keys=[""],
     random_seeds=random_seeds,
     metrics=metrics,

--- a/subcell_pipeline/analysis/dimensionality_reduction/_run_pacmap_on_compression_simulations.py
+++ b/subcell_pipeline/analysis/dimensionality_reduction/_run_pacmap_on_compression_simulations.py
@@ -36,14 +36,14 @@ from subcell_pipeline.analysis.dimensionality_reduction.pacmap_dim_reduction imp
 """
 ## Define simulation conditions
 
-Defines the `COMPRESSION_VELOCITY` simulation series, which compresses a single
-500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with
-five replicates each (random seeds 1, 2, 3, 4, and 5).
+Defines the `ACTIN_COMPRESSION_VELOCITY` simulation series, which compresses a
+single 500 nm actin fiber at four different velocities (4.7, 15, 47, and 150
+μm/s) with five replicates each (random seeds 1, 2, 3, 4, and 5).
 """
 
 # %%
 # Name of the simulation series
-series_name: str = "COMPRESSION_VELOCITY"
+series_name: str = "ACTIN_COMPRESSION_VELOCITY"
 
 # S3 bucket Cytosim for input and output files
 cytosim_bucket: str = "s3://cytosim-working-bucket"
@@ -70,9 +70,7 @@ yz-plane to the positive y axis, keeping x axis coordinates unchanged. Set
 """
 
 # %%
-readdy_data = get_merged_data(
-    readdy_bucket, f"ACTIN_{series_name}", condition_keys, random_seeds
-)
+readdy_data = get_merged_data(readdy_bucket, series_name, condition_keys, random_seeds)
 readdy_data["simulator"] = "readdy"
 
 # %%

--- a/subcell_pipeline/analysis/dimensionality_reduction/_run_pacmap_on_compression_simulations.py
+++ b/subcell_pipeline/analysis/dimensionality_reduction/_run_pacmap_on_compression_simulations.py
@@ -57,6 +57,9 @@ random_seeds: list[int] = [1, 2, 3, 4, 5]
 # List of condition file keys for each velocity
 condition_keys: list[str] = ["0047", "0150", "0470", "1500"]
 
+# Location to save analysis results (S3 bucket or local path)
+save_location: str = "s3://subcell-working-bucket"
+
 # %% [markdown]
 """
 ## Load merged data
@@ -89,7 +92,9 @@ data["velocity"] = data["key"].astype("int") / 10
 """
 
 # %%
-plot_fibers_by_key_and_seed(data)
+plot_fibers_by_key_and_seed(
+    data, save_location, "dimensionality_reduction/actin_compression_aligned_fibers.png"
+)
 
 # %% [markdown]
 """
@@ -120,4 +125,9 @@ features = {
     "REPEAT": "viridis",
 }
 
-plot_pacmap_feature_scatter(pacmap_results, features)
+plot_pacmap_feature_scatter(
+    pacmap_results,
+    features,
+    save_location,
+    "dimensionality_reduction/actin_compression_pacmap_feature_scatter.png",
+)

--- a/subcell_pipeline/analysis/dimensionality_reduction/_run_pca_on_compression_simulations.py
+++ b/subcell_pipeline/analysis/dimensionality_reduction/_run_pca_on_compression_simulations.py
@@ -46,14 +46,14 @@ from subcell_pipeline.analysis.dimensionality_reduction.pca_dim_reduction import
 """
 ## Define simulation conditions
 
-Defines the `COMPRESSION_VELOCITY` simulation series, which compresses a single
-500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with
-five replicates each (random seeds 1, 2, 3, 4, and 5).
+Defines the `ACTIN_COMPRESSION_VELOCITY` simulation series, which compresses a
+single 500 nm actin fiber at four different velocities (4.7, 15, 47, and 150
+μm/s) with five replicates each (random seeds 1, 2, 3, 4, and 5).
 """
 
 # %%
 # Name of the simulation series
-series_name: str = "COMPRESSION_VELOCITY"
+series_name: str = "ACTIN_COMPRESSION_VELOCITY"
 
 # S3 bucket Cytosim for input and output files
 cytosim_bucket: str = "s3://cytosim-working-bucket"
@@ -80,9 +80,7 @@ yz-plane to the positive y axis, keeping x axis coordinates unchanged. Set
 """
 
 # %%
-readdy_data = get_merged_data(
-    readdy_bucket, f"ACTIN_{series_name}", condition_keys, random_seeds
-)
+readdy_data = get_merged_data(readdy_bucket, series_name, condition_keys, random_seeds)
 readdy_data["simulator"] = "readdy"
 
 # %%

--- a/subcell_pipeline/analysis/dimensionality_reduction/_run_pca_on_compression_simulations.py
+++ b/subcell_pipeline/analysis/dimensionality_reduction/_run_pca_on_compression_simulations.py
@@ -114,7 +114,10 @@ time_map = {
 }
 
 save_aligned_fibers(
-    data, time_map, save_location, "actin_compression_aligned_fibers.json"
+    data,
+    time_map,
+    save_location,
+    "dimensionality_reduction/actin_compression_aligned_fibers.json",
 )
 
 # %% [markdown]
@@ -123,7 +126,9 @@ save_aligned_fibers(
 """
 
 # %%
-plot_fibers_by_key_and_seed(data)
+plot_fibers_by_key_and_seed(
+    data, save_location, "dimensionality_reduction/actin_compression_aligned_fibers.png"
+)
 
 # %% [markdown]
 """
@@ -139,7 +144,7 @@ pca_results, pca = run_pca(data)
 """
 
 # %%
-save_pickle(save_location, "actin_compression_pca.pkl", pca)
+save_pickle(save_location, "dimensionality_reduction/actin_compression_pca.pkl", pca)
 
 # %% [markdown]
 """
@@ -151,7 +156,10 @@ entries. Pre-shuffled data is useful for scatter plots showing each individual
 
 # %%
 save_pca_results(
-    pca_results, save_location, "actin_compression_pca_results.csv", resample=True
+    pca_results,
+    save_location,
+    "dimensionality_reduction/actin_compression_pca_results.csv",
+    resample=True,
 )
 
 # %% [markdown]
@@ -161,7 +169,9 @@ save_pca_results(
 
 # %%
 save_pca_trajectories(
-    pca_results, save_location, "actin_compression_pca_trajectories.json"
+    pca_results,
+    save_location,
+    "dimensionality_reduction/actin_compression_pca_trajectories.json",
 )
 
 # %% [markdown]
@@ -175,7 +185,12 @@ points: list[list[float]] = [
     [-600, -400, -200, 0, 200],
 ]
 
-save_pca_transforms(pca, points, save_location, "actin_compression_pca_transforms.json")
+save_pca_transforms(
+    pca,
+    points,
+    save_location,
+    "dimensionality_reduction/actin_compression_pca_transforms.json",
+)
 
 # %% [markdown]
 """
@@ -198,7 +213,13 @@ features = {
     "REPEAT": "viridis",
 }
 
-plot_pca_feature_scatter(pca_results, features, pca)
+plot_pca_feature_scatter(
+    pca_results,
+    features,
+    pca,
+    save_location,
+    "dimensionality_reduction/actin_compression_pca_feature_scatter.png",
+)
 
 # %% [markdown]
 """
@@ -206,4 +227,9 @@ plot_pca_feature_scatter(pca_results, features, pca)
 """
 
 # %%
-plot_pca_inverse_transform(pca, pca_results)
+plot_pca_inverse_transform(
+    pca,
+    pca_results,
+    save_location,
+    "dimensionality_reduction/actin_compression_pca_inverse_transform.png",
+)

--- a/subcell_pipeline/analysis/dimensionality_reduction/fiber_data.py
+++ b/subcell_pipeline/analysis/dimensionality_reduction/fiber_data.py
@@ -1,11 +1,14 @@
 """Methods for fiber data merging and alignment."""
 
+from typing import Optional
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from io_collection.keys.check_key import check_key
 from io_collection.load.load_dataframe import load_dataframe
 from io_collection.save.save_dataframe import save_dataframe
+from io_collection.save.save_figure import save_figure
 from io_collection.save.save_json import save_json
 
 
@@ -211,7 +214,11 @@ def save_aligned_fibers(
     save_json(save_location, save_key, output)
 
 
-def plot_fibers_by_key_and_seed(data: pd.DataFrame) -> None:
+def plot_fibers_by_key_and_seed(
+    data: pd.DataFrame,
+    save_location: Optional[str] = None,
+    save_key: str = "aligned_fibers_by_key_and_seed.png",
+) -> None:
     """
     Plot simulated fiber data for each condition key and random seed.
 
@@ -219,12 +226,16 @@ def plot_fibers_by_key_and_seed(data: pd.DataFrame) -> None:
     ----------
     data
         Simulated fiber data.
+    save_location
+        Location for output file (local path or S3 bucket).
+    save_key
+        Name key for output file.
     """
 
     rows = data["key"].unique()
     cols = data["seed"].unique()
 
-    _, ax = plt.subplots(
+    figure, ax = plt.subplots(
         len(rows), len(cols), figsize=(10, 6), sharey=True, sharex=True
     )
 
@@ -246,3 +257,6 @@ def plot_fibers_by_key_and_seed(data: pd.DataFrame) -> None:
 
     plt.tight_layout()
     plt.show()
+
+    if save_location is not None:
+        save_figure(save_location, save_key, figure)

--- a/subcell_pipeline/analysis/dimensionality_reduction/pacmap_dim_reduction.py
+++ b/subcell_pipeline/analysis/dimensionality_reduction/pacmap_dim_reduction.py
@@ -1,7 +1,10 @@
 """Methods for dimensionality reduction using PaCMAP."""
 
+from typing import Optional
+
 import matplotlib.pyplot as plt
 import pandas as pd
+from io_collection.save.save_figure import save_figure
 from pacmap import PaCMAP
 
 from subcell_pipeline.analysis.dimensionality_reduction.fiber_data import reshape_fibers
@@ -39,7 +42,12 @@ def run_pacmap(data: pd.DataFrame) -> tuple[pd.DataFrame, PaCMAP]:
     return pacmap_results, pacmap
 
 
-def plot_pacmap_feature_scatter(data: pd.DataFrame, features: dict) -> None:
+def plot_pacmap_feature_scatter(
+    data: pd.DataFrame,
+    features: dict,
+    save_location: Optional[str] = None,
+    save_key: str = "pacmap_feature_scatter.png",
+) -> None:
     """
     Plot scatter of PaCMAP embedding colored by the given features.
 
@@ -49,9 +57,15 @@ def plot_pacmap_feature_scatter(data: pd.DataFrame, features: dict) -> None:
         PaCMAP results data.
     features
         Map of feature name to coloring.
+    save_location
+        Location for output file (local path or S3 bucket).
+    save_key
+        Name key for output file.
     """
 
-    _, ax = plt.subplots(1, len(features), figsize=(10, 3), sharey=True, sharex=True)
+    figure, ax = plt.subplots(
+        1, len(features), figsize=(10, 3), sharey=True, sharex=True
+    )
 
     for index, (feature, colors) in enumerate(features.items()):
         if isinstance(colors, dict):
@@ -84,3 +98,6 @@ def plot_pacmap_feature_scatter(data: pd.DataFrame, features: dict) -> None:
 
     plt.tight_layout()
     plt.show()
+
+    if save_location is not None:
+        save_figure(save_location, save_key, figure)

--- a/subcell_pipeline/analysis/dimensionality_reduction/pca_dim_reduction.py
+++ b/subcell_pipeline/analysis/dimensionality_reduction/pca_dim_reduction.py
@@ -1,11 +1,13 @@
 """Methods for dimensionality reduction using PCA."""
 
 import random
+from typing import Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from io_collection.save.save_dataframe import save_dataframe
+from io_collection.save.save_figure import save_figure
 from io_collection.save.save_json import save_json
 from sklearn.decomposition import PCA
 
@@ -149,7 +151,13 @@ def save_pca_transforms(
     save_json(save_location, save_key, output)
 
 
-def plot_pca_feature_scatter(data: pd.DataFrame, features: dict, pca: PCA) -> None:
+def plot_pca_feature_scatter(
+    data: pd.DataFrame,
+    features: dict,
+    pca: PCA,
+    save_location: Optional[str] = None,
+    save_key: str = "pca_feature_scatter.png",
+) -> None:
     """
     Plot scatter of PCA components colored by the given features.
 
@@ -161,9 +169,15 @@ def plot_pca_feature_scatter(data: pd.DataFrame, features: dict, pca: PCA) -> No
         Map of feature name to coloring.
     pca
         PCA object.
+    save_location
+        Location for output file (local path or S3 bucket).
+    save_key
+        Name key for output file.
     """
 
-    _, ax = plt.subplots(1, len(features), figsize=(10, 3), sharey=True, sharex=True)
+    figure, ax = plt.subplots(
+        1, len(features), figsize=(10, 3), sharey=True, sharex=True
+    )
 
     for index, (feature, colors) in enumerate(features.items()):
         if isinstance(colors, dict):
@@ -197,8 +211,16 @@ def plot_pca_feature_scatter(data: pd.DataFrame, features: dict, pca: PCA) -> No
     plt.tight_layout()
     plt.show()
 
+    if save_location is not None:
+        save_figure(save_location, save_key, figure)
 
-def plot_pca_inverse_transform(pca: PCA, pca_results: pd.DataFrame) -> None:
+
+def plot_pca_inverse_transform(
+    pca: PCA,
+    pca_results: pd.DataFrame,
+    save_location: Optional[str] = None,
+    save_key: str = "pca_inverse_transform.png",
+) -> None:
     """
     Plot inverse transform of PCA.
 
@@ -208,9 +230,13 @@ def plot_pca_inverse_transform(pca: PCA, pca_results: pd.DataFrame) -> None:
         PCA object.
     pca_results
         PCA results data.
+    save_location
+        Location for output file (local path or S3 bucket).
+    save_key
+        Name key for output file.
     """
 
-    _, ax = plt.subplots(2, 3, figsize=(10, 6))
+    figure, ax = plt.subplots(2, 3, figsize=(10, 6))
 
     points = np.arange(-2, 2, 0.5)
     stdev_pc1 = pca_results["PCA1"].std(ddof=0)
@@ -244,3 +270,6 @@ def plot_pca_inverse_transform(pca: PCA, pca_results: pd.DataFrame) -> None:
 
     plt.tight_layout()
     plt.show()
+
+    if save_location is not None:
+        save_figure(save_location, save_key, figure)

--- a/subcell_pipeline/analysis/tomography_data/_analyze_actin_cme_tomography_data.py
+++ b/subcell_pipeline/analysis/tomography_data/_analyze_actin_cme_tomography_data.py
@@ -98,7 +98,7 @@ unbranched_df = get_unbranched_tomography_data(
 
 # %%
 plot_tomography_data_by_dataset(
-    branched_df, bucket, f"{name}/{name}_plots_branched.png"
+    branched_df, bucket, f"{name}/{name}_plots_branched_%s.png"
 )
 
 # %% [markdown]
@@ -108,7 +108,7 @@ plot_tomography_data_by_dataset(
 
 # %%
 plot_tomography_data_by_dataset(
-    unbranched_df, bucket, f"{name}/{name}_plots_unbranched.png"
+    unbranched_df, bucket, f"{name}/{name}_plots_unbranched_%s.png"
 )
 
 # %% [markdown]
@@ -156,5 +156,5 @@ sampled_data = sample_tomography_data(
 
 # %%
 plot_tomography_data_by_dataset(
-    sampled_data, bucket, f"{name}/{name}_plots_all_sampled.png"
+    sampled_data, bucket, f"{name}/{name}_plots_all_sampled_%s.png"
 )

--- a/subcell_pipeline/analysis/tomography_data/tomography_data.py
+++ b/subcell_pipeline/analysis/tomography_data/tomography_data.py
@@ -1,6 +1,6 @@
 """Methods for analyzing tomography data."""
 
-import os
+from typing import Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -286,8 +286,8 @@ def sample_tomography_data(
 
 def plot_tomography_data_by_dataset(
     data: pd.DataFrame,
-    bucket: str,
-    output_key: str,
+    save_location: Optional[str] = None,
+    save_key_template: str = "tomography_data_%s.png",
 ) -> None:
     """
     Plot tomography data for each dataset.
@@ -296,13 +296,13 @@ def plot_tomography_data_by_dataset(
     ----------
     data
         Tomography data.
-    bucket
-        Where to upload the results.
-    output_key
-        File key for results.
+    save_location
+        Location for output file (local path or S3 bucket).
+    save_key_template
+        Name key template for output file.
     """
-    for dataset, group in data.groupby("dataset"):
 
+    for dataset, group in data.groupby("dataset"):
         figure, ax = plt.subplots(1, 3, figsize=(6, 2))
         ax[1].set_title(dataset)
 
@@ -318,5 +318,6 @@ def plot_tomography_data_by_dataset(
             ax[1].plot(fiber["xpos"], fiber["zpos"], marker="o", ms=1, lw=1)
             ax[2].plot(fiber["ypos"], fiber["zpos"], marker="o", ms=1, lw=1)
 
-        base_name, ext = os.path.splitext(output_key)
-        save_figure(bucket, f"{base_name}_{dataset}.{ext}", figure)
+        if save_location is not None:
+            save_key = save_key_template % dataset
+            save_figure(save_location, save_key, figure)

--- a/subcell_pipeline/analysis/wall_clock_time/README.md
+++ b/subcell_pipeline/analysis/wall_clock_time/README.md
@@ -2,6 +2,6 @@
 
 ## Single actin fiber compressed at different compression velocities
 
-Analysis extracts wall clock times from the `COMPRESSION_VELOCITY` simulation series, which simulates compression of a single 500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with five replicates.
+Analysis extracts wall clock times from the `ACTIN_COMPRESSION_VELOCITY` simulation series, which simulates compression of a single 500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with five replicates.
 
 - **Summarize Cytosim compression simulation wall clock times** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/analysis/wall_clock_time/_summarize_cytosim_compression_simulation_wall_clock_times.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/analysis/wall_clock_time/_summarize_cytosim_compression_simulation_wall_clock_times.html))

--- a/subcell_pipeline/analysis/wall_clock_time/_summarize_cytosim_compression_simulation_wall_clock_times.py
+++ b/subcell_pipeline/analysis/wall_clock_time/_summarize_cytosim_compression_simulation_wall_clock_times.py
@@ -26,14 +26,14 @@ from subcell_pipeline.analysis.wall_clock_time.log_data import (
 """
 ## Define simulation conditions
 
-Defines the `COMPRESSION_VELOCITY` simulation series, which compresses a single
-500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with
-five replicates each (random seeds 1, 2, 3, 4, and 5).
+Defines the `ACTIN_COMPRESSION_VELOCITY` simulation series, which compresses a
+single 500 nm actin fiber at four different velocities (4.7, 15, 47, and 150
+μm/s) with five replicates each (random seeds 1, 2, 3, 4, and 5).
 """
 
 # %%
 # Name of the simulation series
-series_name: str = "COMPRESSION_VELOCITY"
+series_name: str = "ACTIN_COMPRESSION_VELOCITY"
 
 # S3 bucket for input and output files
 bucket: str = "s3://cytosim-working-bucket"

--- a/subcell_pipeline/simulation/batch_simulations.py
+++ b/subcell_pipeline/simulation/batch_simulations.py
@@ -96,7 +96,7 @@ def generate_configs_from_template(
         for index, seed in enumerate(random_seeds):
             config_key = f"{series_name}/{timestamp}/configs/{group_key}_{index}.cym"
             config_contents = contents.replace("{{RANDOM_SEED}}", str(seed))
-            print(f"Saving config for [ {match} ] for seed {seed} to [ {config_key}]")
+            print(f"Saving config for [ {match} ] for seed {seed} to [ {config_key} ]")
             save_text(bucket, config_key, config_contents)
 
     return group_keys

--- a/subcell_pipeline/simulation/cytosim/README.md
+++ b/subcell_pipeline/simulation/cytosim/README.md
@@ -7,14 +7,14 @@ Simulations and processing for cytoskeleton simulation engine [Cytosim](https://
 
 ## Baseline single actin fiber with no compression
 
-The `NO_COMPRESSION` simulation series simulates a single actin fiber with a free barbed end across five replicates.
+The `ACTIN_NO_COMPRESSION` simulation series simulates a single actin fiber with a free barbed end across five replicates.
 
 - **Run Cytosim single fiber simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim/_run_cytosim_no_compression_batch_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/cytosim/_run_cytosim_no_compression_batch_simulations.html))
 - **Process Cytosim single fiber simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim/_process_cytosim_no_compression_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/cytosim/_process_cytosim_no_compression_simulations.html))
 
 ## Single actin fiber compressed at different compression velocities
 
-The `COMPRESSION_VELOCITY` simulation series simulates compression of a single 500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with five replicates.
+The `ACTIN_COMPRESSION_VELOCITY` simulation series simulates compression of a single 500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with five replicates.
 
 - **Run Cytosim compression simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim/_run_cytosim_compression_batch_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/cytosim/_run_cytosim_compression_batch_simulations.html))
 - **Process Cytosim compression simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/cytosim/_process_cytosim_compression_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/cytosim/_process_cytosim_compression_simulations.html))

--- a/subcell_pipeline/simulation/cytosim/_process_cytosim_compression_simulations.py
+++ b/subcell_pipeline/simulation/cytosim/_process_cytosim_compression_simulations.py
@@ -31,14 +31,14 @@ from subcell_pipeline.simulation.post_processing import sample_simulation_data
 """
 ## Define simulation conditions
 
-Defines the `COMPRESSION_VELOCITY` simulation series, which compresses a single
-500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with
-five replicates each (random seeds 1, 2, 3, 4, and 5).
+Defines the `ACTIN_COMPRESSION_VELOCITY` simulation series, which compresses a
+single 500 nm actin fiber at four different velocities (4.7, 15, 47, and 150
+μm/s) with five replicates each (random seeds 1, 2, 3, 4, and 5).
 """
 
 # %%
 # Name of the simulation series
-series_name: str = "COMPRESSION_VELOCITY"
+series_name: str = "ACTIN_COMPRESSION_VELOCITY"
 
 # S3 bucket for input and output files
 bucket: str = "s3://cytosim-working-bucket"

--- a/subcell_pipeline/simulation/cytosim/_process_cytosim_no_compression_simulations.py
+++ b/subcell_pipeline/simulation/cytosim/_process_cytosim_no_compression_simulations.py
@@ -31,14 +31,14 @@ from subcell_pipeline.simulation.post_processing import sample_simulation_data
 """
 ## Define simulation conditions
 
-Defines the `NO_COMPRESSION` simulation series, which simulates a single actin
-fiber with a free barbed end across five replicates (random seeds 1, 2, 3, 4,
-and 5).
+Defines the `ACTIN_NO_COMPRESSION` simulation series, which simulates a single
+actin fiber with a free barbed end across five replicates (random seeds 1, 2, 3,
+4, and 5).
 """
 
 # %%
 # Name of the simulation series
-series_name: str = "NO_COMPRESSION"
+series_name: str = "ACTIN_NO_COMPRESSION"
 
 # S3 bucket for input and output files
 bucket: str = "s3://cytosim-working-bucket"

--- a/subcell_pipeline/simulation/cytosim/_run_cytosim_compression_batch_simulations.py
+++ b/subcell_pipeline/simulation/cytosim/_run_cytosim_compression_batch_simulations.py
@@ -60,14 +60,14 @@ from preconfig import Preconfig  # noqa: E402
 """
 ## Define simulation conditions
 
-Defines the `COMPRESSION_VELOCITY` simulation series, which compresses a single
-500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with
-five replicates each (random seeds 1, 2, 3, 4, and 5).
+Defines the `ACTIN_COMPRESSION_VELOCITY` simulation series, which compresses a
+single 500 nm actin fiber at four different velocities (4.7, 15, 47, and 150
+μm/s) with five replicates each (random seeds 1, 2, 3, 4, and 5).
 """
 
 # %%
 # Name of the simulation series
-series_name: str = "COMPRESSION_VELOCITY"
+series_name: str = "ACTIN_COMPRESSION_VELOCITY"
 
 # S3 bucket for input and output files
 bucket: str = "s3://cytosim-working-bucket"

--- a/subcell_pipeline/simulation/cytosim/_run_cytosim_no_compression_batch_simulations.py
+++ b/subcell_pipeline/simulation/cytosim/_run_cytosim_no_compression_batch_simulations.py
@@ -48,14 +48,14 @@ cytosim_path: Path = Path(os.getenv("CYTOSIM", "."))
 """
 ## Define simulation conditions
 
-Defines the `NO_COMPRESSION` simulation series, which simulates a single actin
-fiber with a free barbed end across five replicates (random seeds 1, 2, 3, 4,
-and 5).
+Defines the `ACTIN_NO_COMPRESSION` simulation series, which simulates a single
+actin fiber with a free barbed end across five replicates (random seeds 1, 2, 3,
+4, and 5).
 """
 
 # %%
 # Name of the simulation series
-series_name: str = "NO_COMPRESSION"
+series_name: str = "ACTIN_NO_COMPRESSION"
 
 # S3 bucket for input and output files
 bucket: str = "s3://cytosim-working-bucket"

--- a/subcell_pipeline/simulation/readdy/README.md
+++ b/subcell_pipeline/simulation/readdy/README.md
@@ -7,14 +7,14 @@ Simulations and processing for particle-based reaction-diffusion simulator [ReaD
 
 ## Baseline single actin fiber with no compression
 
-The `NO_COMPRESSION` simulation series simulates a single actin fiber with a free barbed end across five replicates.
+The `ACTIN_NO_COMPRESSION` simulation series simulates a single actin fiber with a free barbed end across five replicates.
 
 - **Run ReaDDy single fiber simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/readdy/_run_readdy_no_compression_batch_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/readdy/_run_readdy_no_compression_batch_simulations.html))
 - **Process ReaDDy single fiber simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/readdy/_process_readdy_no_compression_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/readdy/_process_readdy_no_compression_simulations.html))
 
 ## Single actin fiber compressed at different compression velocities
 
-The `COMPRESSION_VELOCITY` simulation series simulates compression of a single 500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with five replicates.
+The `ACTIN_COMPRESSION_VELOCITY` simulation series simulates compression of a single 500 nm actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with five replicates.
 
 - **Run ReaDDy compression simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/readdy/_run_readdy_compression_batch_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/readdy/_run_readdy_compression_batch_simulations.html))
 - **Process ReaDDy compression simulations** ([source](https://github.com/simularium/subcell-pipeline/blob/main/subcell_pipeline/simulation/readdy/_process_readdy_compression_simulations.py) | [notebook](https://simularium.github.io/subcell-pipeline/_notebooks/simulation/readdy/_process_readdy_compression_simulations.html))

--- a/subcell_pipeline/visualization/_visualize_combined_trajectories.py
+++ b/subcell_pipeline/visualization/_visualize_combined_trajectories.py
@@ -37,11 +37,8 @@ buckets: dict[str, str] = {
     "cytosim": "s3://cytosim-working-bucket",
 }
 
-# Names of the simulation series for each simulator
-series_names: dict[str, str] = {
-    "readdy": "ACTIN_COMPRESSION_VELOCITY",
-    "cytosim": "COMPRESSION_VELOCITY",
-}
+# Name of the simulation series
+series_name: str = "ACTIN_COMPRESSION_VELOCITY"
 
 # List of condition file keys for each velocity
 condition_keys: list[str] = ["0047", "0150", "0470", "1500"]
@@ -86,7 +83,7 @@ Simularium.
 # %%
 visualize_combined_trajectories(
     buckets,
-    series_names,
+    series_name,
     condition_keys,
     replicates,
     n_timepoints,

--- a/subcell_pipeline/visualization/_visualize_cytosim_trajectories.py
+++ b/subcell_pipeline/visualization/_visualize_cytosim_trajectories.py
@@ -64,8 +64,8 @@ metrics = [
 """
 ## Visualize compression simulations
 
-The `COMPRESSION_VELOCITY` simulation series compresses a single 500 nm actin
-fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with five
+The `ACTIN_COMPRESSION_VELOCITY` simulation series compresses a single 500 nm
+actin fiber at four different velocities (4.7, 15, 47, and 150 μm/s) with five
 replicates each.
 
 Iterate through all condition keys and replicates to load simulation output
@@ -78,7 +78,7 @@ and replicate already exists and recalculate is False, visualization is skipped.
 
 # %%
 # Name of the simulation series
-compression_series_name: str = "COMPRESSION_VELOCITY"
+compression_series_name: str = "ACTIN_COMPRESSION_VELOCITY"
 
 # List of condition file keys for each velocity
 compression_condition_keys: list[str] = ["0047", "0150", "0470", "1500"]
@@ -99,8 +99,8 @@ visualize_individual_cytosim_trajectories(
 """
 ## Visualize no compression simulations
 
-The `NO_COMPRESSION` simulation series simulates a single actin fiber with a
-free barbed end across five replicates.
+The `ACTIN_NO_COMPRESSION` simulation series simulates a single actin fiber with
+a free barbed end across five replicates.
 
 Iterate through all replicates to load simulation output files and visualize
 them. If the visualization file for a given replicate already exists and
@@ -112,7 +112,7 @@ recalculate is False, visualization is skipped.
 
 # %%
 # Name of the simulation series
-no_compression_series_name: str = "NO_COMPRESSION"
+no_compression_series_name: str = "ACTIN_NO_COMPRESSION"
 
 # %%
 visualize_individual_cytosim_trajectories(

--- a/subcell_pipeline/visualization/combined_trajectory.py
+++ b/subcell_pipeline/visualization/combined_trajectory.py
@@ -130,7 +130,7 @@ def _add_combined_plots(
 
 def visualize_combined_trajectories(
     buckets: dict[str, str],
-    series_names: dict[str, str],
+    series_name: str,
     condition_keys: list[str],
     replicates: list[int],
     n_timepoints: int,
@@ -148,8 +148,8 @@ def visualize_combined_trajectories(
     buckets
         Names of S3 buckets for input and output files for each simulator and
         visualization.
-    series_names
-        Names of simulation series for each simulator.
+    series_name
+        Name of simulation series.
     condition_keys
         List of condition keys.
     replicates
@@ -174,7 +174,6 @@ def visualize_combined_trajectories(
 
     for simulator, color in simulator_colors.items():
         bucket = buckets[simulator]
-        series_name = series_names[simulator]
 
         # Load calculated compression metric data.
         if metrics is not None:


### PR DESCRIPTION
_Estimated size: small_

For consistency, updated the names of the Cytosim simulation series:

- `COMPRESSION_VELOCITY` to  `ACTIN_COMPRESSION_VELOCITY`
- `NO_COMPRESSION` to `ACTIN_NO_COMPRESSION`

which now matches the names for the ReaDDy simulation series. All data files in the buckets are renamed as well (spot checked a couple conditions to make sure the notebooks run, then copied over from the old data).

As we discussed previously, I also updated all the figure saving methods to be consistent between the different analysis types. They now all use `save_location` (which can be an S3 bucket or a local path) and a `save_key` (or `save_key_template` if multiple files are saved). The `save_location` can optionally be set to `None` to not save the figure.